### PR TITLE
Bug: Additional files not regonized

### DIFF
--- a/Buildalyzer.sln
+++ b/Buildalyzer.sln
@@ -41,6 +41,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\test-report.yml = .github\workflows\test-report.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "projects", "projects", "{A7A6E392-4132-4773-97DC-1815D773CFA5}"
+	ProjectSection(SolutionItems) = preProject
+		tests\projects\ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj = tests\projects\ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +84,7 @@ Global
 		{A46CB47B-1561-41F2-AF52-F0E1DC2C886A} = {A52BD74E-3894-4A6E-8B9A-143A004F07F3}
 		{4FD47340-8E8E-4338-BB20-E4AF8E29E78D} = {5C0EF6BC-7A9B-4B29-9BFB-4098842FEBB6}
 		{7A15ECCE-3AB1-4F0A-A1A0-942E7982C2E2} = {4FD47340-8E8E-4338-BB20-E4AF8E29E78D}
+		{A7A6E392-4132-4773-97DC-1815D773CFA5} = {2D6F1622-8D17-4D49-A9D1-E4AEAFE99370}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1716863C-E9E2-4074-B557-E38CEB3B5C84}

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -704,10 +704,31 @@ public class SimpleProjectsFixture
         StringWriter log = new StringWriter();
         IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
 
-        // When + then
-        analyzer.Build().First().AdditionalFiles.Select(Path.GetFileName)
-            .Should().BeEquivalentTo("message.txt");
-    }
+        // When
+        IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+
+        [Test]
+        public void GetsProjectFileAsAdditionalFile()
+        {
+            // Given
+            StringWriter log = new StringWriter();
+            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj", log);
+
+            // When
+            IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+
+            // Then
+            additionalFiles.ShouldBe(new[] { "ProjectFileAsAdditionalFile.csproj" }, log.ToString());
+        }
+
+        private static IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log)
+        {
+            IProjectAnalyzer analyzer = new AnalyzerManager(
+                new AnalyzerManagerOptions
+                {
+                    LogWriter = log
+                })
+                .GetProject(GetProjectPath(projectFile));
 
     [Test]
     public void HandlesProcessFailure()

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -716,8 +716,10 @@ public class SimpleProjectsFixture
         using var log = new StringWriter();
         IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj", log);
 
+        var builds = analyzer.Build();
+
         // When + then
-        analyzer.Build().First().AdditionalFiles
+        builds.First().AdditionalFiles
             .Select(Path.GetFileName)
             .Should().BeEquivalentTo("ProjectFileAsAdditionalFile.csproj");
     }

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -138,7 +138,7 @@ public class SimpleProjectsFixture
     [Test]
     public void GetsReferences(
         [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-        [ValueSource(nameof(ProjectFiles))] [NotNull] string projectFile)
+        [ValueSource(nameof(ProjectFiles))][NotNull] string projectFile)
     {
         // Given
         StringWriter log = new StringWriter();
@@ -704,31 +704,23 @@ public class SimpleProjectsFixture
         StringWriter log = new StringWriter();
         IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
 
-        // When
-        IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+        // When + then
+        analyzer.Build().First().AdditionalFiles.Select(Path.GetFileName)
+            .Should().BeEquivalentTo("message.txt");
+    }
 
-        [Test]
-        public void GetsProjectFileAsAdditionalFile()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj", log);
+    [Test]
+    public void GetsProjectFileAsAdditionalFile()
+    {
+        // Given
+        using var log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj", log);
 
-            // When
-            IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
-
-            // Then
-            additionalFiles.ShouldBe(new[] { "ProjectFileAsAdditionalFile.csproj" }, log.ToString());
-        }
-
-        private static IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log)
-        {
-            IProjectAnalyzer analyzer = new AnalyzerManager(
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                })
-                .GetProject(GetProjectPath(projectFile));
+        // When + then
+        analyzer.Build().First().AdditionalFiles
+            .Select(Path.GetFileName)
+            .Should().BeEquivalentTo("ProjectFileAsAdditionalFile.csproj");
+    }
 
     [Test]
     public void HandlesProcessFailure()

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -716,12 +716,15 @@ public class SimpleProjectsFixture
         using var log = new StringWriter();
         IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectFileAsAdditionalFile\ProjectFileAsAdditionalFile.csproj", log);
 
+        // When
         var builds = analyzer.Build();
 
-        // When + then
-        builds.First().AdditionalFiles
-            .Select(Path.GetFileName)
-            .Should().BeEquivalentTo("ProjectFileAsAdditionalFile.csproj");
+        // Then
+        var v6_0 = builds.Single(b => b.TargetFramework == "net6.0");
+        var v5_0 = builds.Single(b => b.TargetFramework == "net5.0");
+
+        v6_0.AdditionalFiles.Select(Path.GetFileName).Should().BeEquivalentTo("ProjectFileAsAdditionalFile.csproj");
+        v5_0.AdditionalFiles.Select(Path.GetFileName).Should().BeEquivalentTo("ProjectFileAsAdditionalFile.csproj");
     }
 
     [Test]

--- a/tests/projects/ProjectFileAsAdditionalFile/ProjectFileAsAdditionalFile.csproj
+++ b/tests/projects/ProjectFileAsAdditionalFile/ProjectFileAsAdditionalFile.csproj
@@ -1,17 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ProductName>Test project</ProductName>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-    <Nullable>annotations</Nullable>
-  </PropertyGroup>
+ 
 
   <PropertyGroup Condition="'1' == '1'">
     <ProductName>Test project</ProductName>

--- a/tests/projects/ProjectFileAsAdditionalFile/ProjectFileAsAdditionalFile.csproj
+++ b/tests/projects/ProjectFileAsAdditionalFile/ProjectFileAsAdditionalFile.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ProductName>Test project</ProductName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'1' == '1'">
+    <ProductName>Test project</ProductName>
+  </PropertyGroup>
+ 
+  <ItemGroup>
+    <AdditionalFiles Include="*.??proj" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/projects/ProjectFileAsAdditionalFile/SomeClass.cs
+++ b/tests/projects/ProjectFileAsAdditionalFile/SomeClass.cs
@@ -1,0 +1,3 @@
+﻿namespace ProjectWithAdditionalFile;
+
+public class SomeClass { }


### PR DESCRIPTION
As mentioned in #243, I noticed that in some projects additional files (and other properties as well I guess, but that was not what I was investigating) are not recognized.

I've added created this PR, that adds a replay where the additional files are not available in the `AnalyzerResult`. 

1. I noticed (so far) that `EventProcessor.MessageRaised(object sender, BuildMessageEventArgs e)` is triggered only for v6.0.
2. For the (existing) test that succeeds, only one TFM is detected, for this failing test, both v6.0 and v5.0 are added. The latter lacks the additional files, but is used to build anyway.
3. If change the targets to only build .NET 5.0, or for .NET 8.0 and .NET 6.0 combined, everything works just fine.

I'll update mine findings here.

For some background, I use Buildalyzer to test Roslyn Analyzers that check for issues in .NET project files, such as MS Build project files, and RESX files. Access to the additional files is the perquisite for those tests to work. See: [dotnet-project-file-analyzers](https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/99)