### PR TITLE
Update to .NET 8 and C# 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           include-prerelease: true
           dotnet-version: |
             3.1.x
-            7.0.x
+            8.0.x
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,6 @@
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="*" PrivateAssets="All"/>
-    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="*" PrivateAssets="all" /> 
     <PackageReference Include="Roslynator.Analyzers" Version="*" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="All"/>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,8 +34,9 @@
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="*" PrivateAssets="All"/>
-	<PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="All"/>
+    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="*" PrivateAssets="all" /> 
     <PackageReference Include="Roslynator.Analyzers" Version="*" PrivateAssets="All"/>
+    <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
-    <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.10.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,16 @@
 <Project>
+
   <PropertyGroup>
     <Version Condition="'$(BuildalyzerVersion)' == ''">1.0.0</Version>
     <Version Condition="'$(BuildalyzerVersion)' != ''">$(BuildalyzerVersion)</Version>
     <AssemblyVersion>$(Version.Split('-')[0])</AssemblyVersion>
     <FileVersion>$(Version.Split('-')[0])</FileVersion>
-    <Authors>Dave Glick and contributors</Authors>
-    <Company>Dave Glick and contributors</Company>
+    <Authors>Dave Glick, Pablo Monteiro, and contributors</Authors>
+    <Company>Dave Glick, Pablo Monteiro, and contributors</Company>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/daveaglick/Buildalyzer</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/daveaglick/Buildalyzer.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/phmonte/Buildalyzer</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/phmonte/Buildalyzer.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -17,20 +18,24 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\LICENSE.md" Pack="true" PackagePath=""/>
     <None Include="$(MSBuildThisFileDirectory)\icon.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
-  <ItemGroup>
+
+<ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.10.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28" PrivateAssets="All"/>
   </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="*" PrivateAssets="All"/>
+	<PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="*" PrivateAssets="All"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
+++ b/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <Description>The MSBuild logger for Buildalyzer. Not intended to be used directly.</Description>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);PackLogger</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" PrivateAssets="All" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" PrivateAssets="All" IsLogger="true" />
@@ -26,4 +29,5 @@
       <BuildOutputInPackage Include="@(LoggerFiles)" />
     </ItemGroup>
   </Target>
+
 </Project>

--- a/src/Buildalyzer.Logger/BuildalyzerLogger.cs
+++ b/src/Buildalyzer.Logger/BuildalyzerLogger.cs
@@ -1,96 +1,93 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.Build.Framework;
 using MsBuildPipeLogger;
 
-namespace Buildalyzer.Logger
+namespace Buildalyzer.Logger;
+
+public class BuildalyzerLogger : PipeLogger
 {
-    public class BuildalyzerLogger : PipeLogger
+    private string _pipeHandleAsString;
+    private bool _logEverything;
+
+    public override void Initialize(IEventSource eventSource)
     {
-        private string _pipeHandleAsString;
-        private bool _logEverything;
-
-        public override void Initialize(IEventSource eventSource)
+        // Parse the parameters
+        string[] parameters = Parameters.Split(';').Select(x => x.Trim()).ToArray();
+        if (parameters.Length != 2)
         {
-            // Parse the parameters
-            string[] parameters = Parameters.Split(';').Select(x => x.Trim()).ToArray();
-            if (parameters.Length != 2)
-            {
-                throw new LoggerException("Unexpected number of parameters");
-            }
-            _pipeHandleAsString = parameters[0];
-            if (!bool.TryParse(parameters[1], out _logEverything))
-            {
-                throw new LoggerException("Second parameter (log everything) should be a bool");
-            }
-
-            base.Initialize(eventSource);
+            throw new LoggerException("Unexpected number of parameters");
+        }
+        _pipeHandleAsString = parameters[0];
+        if (!bool.TryParse(parameters[1], out _logEverything))
+        {
+            throw new LoggerException("Second parameter (log everything) should be a bool");
         }
 
-        protected override void InitializeEnvironmentVariables()
+        base.Initialize(eventSource);
+    }
+
+    protected override void InitializeEnvironmentVariables()
+    {
+        // Only register the extra logging environment variables if logging everything
+        if (_logEverything)
         {
-            // Only register the extra logging environment variables if logging everything
-            if (_logEverything)
-            {
-                base.InitializeEnvironmentVariables();
-            }
+            base.InitializeEnvironmentVariables();
+        }
+    }
+
+    protected override IPipeWriter InitializePipeWriter() => new AnonymousPipeWriter(_pipeHandleAsString);
+
+    protected override void InitializeEvents(IEventSource eventSource)
+    {
+        if (eventSource is null)
+        {
+            throw new ArgumentNullException(nameof(eventSource));
         }
 
-        protected override IPipeWriter InitializePipeWriter() => new AnonymousPipeWriter(_pipeHandleAsString);
-
-        protected override void InitializeEvents(IEventSource eventSource)
+        if (_logEverything)
         {
-            if (eventSource is null)
-            {
-                throw new ArgumentNullException(nameof(eventSource));
-            }
-
-            if (_logEverything)
-            {
-                base.InitializeEvents(eventSource);
-                return;
-            }
-
-            // Only log what we need for Buildalyzer
-            eventSource.ProjectStarted += (_, e) => Pipe.Write(e);
-            eventSource.ProjectFinished += (_, e) => Pipe.Write(e);
-            eventSource.BuildFinished += (_, e) => Pipe.Write(e);
-            eventSource.ErrorRaised += (_, e) => Pipe.Write(e);
-            eventSource.TargetStarted += TargetStarted;
-            eventSource.TargetFinished += TargetFinished;
-            eventSource.MessageRaised += MessageRaised;
+            base.InitializeEvents(eventSource);
+            return;
         }
 
-        private void TargetStarted(object sender, TargetStartedEventArgs e)
-        {
-            // Only send the CoreCompile target
-            if (e.TargetName == "CoreCompile")
-            {
-                Pipe.Write(e);
-            }
-        }
+        // Only log what we need for Buildalyzer
+        eventSource.ProjectStarted += (_, e) => Pipe.Write(e);
+        eventSource.ProjectFinished += (_, e) => Pipe.Write(e);
+        eventSource.BuildFinished += (_, e) => Pipe.Write(e);
+        eventSource.ErrorRaised += (_, e) => Pipe.Write(e);
+        eventSource.TargetStarted += TargetStarted;
+        eventSource.TargetFinished += TargetFinished;
+        eventSource.MessageRaised += MessageRaised;
+    }
 
-        private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    private void TargetStarted(object sender, TargetStartedEventArgs e)
+    {
+        // Only send the CoreCompile target
+        if (e.TargetName == "CoreCompile")
         {
-            // Only send the CoreCompile target
-            if (e.TargetName == "CoreCompile")
-            {
-                Pipe.Write(e);
-            }
+            Pipe.Write(e);
         }
+    }
 
-        private void MessageRaised(object sender, BuildMessageEventArgs e)
+    private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    {
+        // Only send the CoreCompile target
+        if (e.TargetName == "CoreCompile")
         {
-            // Only send if in the Csc Vbc, or the Fsc task
-            if ((e is TaskCommandLineEventArgs cmd &&
-                string.Equals(cmd.TaskName, "Csc", StringComparison.OrdinalIgnoreCase)) ||
-                string.Equals(e.SenderName, "Fsc", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(e.SenderName, "Vbc", StringComparison.OrdinalIgnoreCase))
-            {
-                Pipe.Write(e);
-            }
+            Pipe.Write(e);
+        }
+    }
+
+    private void MessageRaised(object sender, BuildMessageEventArgs e)
+    {
+        // Only send if in the Csc Vbc, or the Fsc task
+        if ((e is TaskCommandLineEventArgs cmd &&
+            string.Equals(cmd.TaskName, "Csc", StringComparison.OrdinalIgnoreCase)) ||
+            string.Equals(e.SenderName, "Fsc", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(e.SenderName, "Vbc", StringComparison.OrdinalIgnoreCase))
+        {
+            Pipe.Write(e);
         }
     }
 }

--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -1,65 +1,63 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Workspaces
+namespace Buildalyzer.Workspaces;
+
+public static class AnalyzerManagerExtensions
 {
-    public static class AnalyzerManagerExtensions
+    /// <summary>
+    /// Instantiates an empty AdhocWorkspace with logging event handlers.
+    /// </summary>
+    internal static AdhocWorkspace CreateWorkspace(this IAnalyzerManager manager)
     {
-        /// <summary>
-        /// Instantiates an empty AdhocWorkspace with logging event handlers.
-        /// </summary>
-        internal static AdhocWorkspace CreateWorkspace(this IAnalyzerManager manager)
+        ILogger logger = manager.LoggerFactory?.CreateLogger<AdhocWorkspace>();
+        AdhocWorkspace workspace = new AdhocWorkspace();
+        workspace.WorkspaceChanged += (sender, args) => logger?.LogDebug($"Workspace changed: {args.Kind.ToString()}{System.Environment.NewLine}");
+        workspace.WorkspaceFailed += (sender, args) => logger?.LogError($"Workspace failed: {args.Diagnostic}{System.Environment.NewLine}");
+        return workspace;
+    }
+
+    public static AdhocWorkspace GetWorkspace(this IAnalyzerManager manager)
+    {
+        if (manager is null)
         {
-            ILogger logger = manager.LoggerFactory?.CreateLogger<AdhocWorkspace>();
-            AdhocWorkspace workspace = new AdhocWorkspace();
-            workspace.WorkspaceChanged += (sender, args) => logger?.LogDebug($"Workspace changed: {args.Kind.ToString()}{System.Environment.NewLine}");
-            workspace.WorkspaceFailed += (sender, args) => logger?.LogError($"Workspace failed: {args.Diagnostic}{System.Environment.NewLine}");
-            return workspace;
+            throw new ArgumentNullException(nameof(manager));
         }
 
-        public static AdhocWorkspace GetWorkspace(this IAnalyzerManager manager)
-        {
-            if (manager is null)
-            {
-                throw new ArgumentNullException(nameof(manager));
-            }
+        // Run builds in parallel
+        List<IAnalyzerResult> results = manager.Projects.Values
+            .AsParallel()
+            .Select(p => p.Build().FirstOrDefault())
+            .Where(x => x != null)
+            .ToList();
 
-            // Run builds in parallel
-            List<IAnalyzerResult> results = manager.Projects.Values
-                .AsParallel()
-                .Select(p => p.Build().FirstOrDefault())
-                .Where(x => x != null)
+        // Create a new workspace and add the solution (if there was one)
+        AdhocWorkspace workspace = manager.CreateWorkspace();
+        if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+        {
+            SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+            workspace.AddSolution(solutionInfo);
+
+            // Sort the projects so the order that they're added to the workspace in the same order as the solution file
+            List<ProjectInSolution> projectsInOrder = manager.SolutionFile.ProjectsInOrder.ToList();
+            results = results
+                .OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))
                 .ToList();
-
-            // Create a new workspace and add the solution (if there was one)
-            AdhocWorkspace workspace = manager.CreateWorkspace();
-            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
-            {
-                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
-                workspace.AddSolution(solutionInfo);
-
-                // Sort the projects so the order that they're added to the workspace in the same order as the solution file
-                List<ProjectInSolution> projectsInOrder = manager.SolutionFile.ProjectsInOrder.ToList();
-                results = results
-                    .OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))
-                    .ToList();
-            }
-
-            // Add each result to the new workspace (sorted in solution order above, if we have a solution)
-            foreach (IAnalyzerResult result in results)
-            {
-                // Check for duplicate project files and don't add them
-                if (workspace.CurrentSolution.Projects.All(p => p.FilePath != result.ProjectFilePath))
-                {
-                    result.AddToWorkspace(workspace, true);
-                }
-            }
-            return workspace;
         }
+
+        // Add each result to the new workspace (sorted in solution order above, if we have a solution)
+        foreach (IAnalyzerResult result in results)
+        {
+            // Check for duplicate project files and don't add them
+            if (workspace.CurrentSolution.Projects.All(p => p.FilePath != result.ProjectFilePath))
+            {
+                result.AddToWorkspace(workspace, true);
+            }
+        }
+        return workspace;
     }
 }

--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,317 +10,316 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 
-namespace Buildalyzer.Workspaces
+namespace Buildalyzer.Workspaces;
+
+public static class AnalyzerResultExtensions
 {
-    public static class AnalyzerResultExtensions
+    /// <summary>
+    /// Gets a Roslyn workspace for the analyzed results.
+    /// </summary>
+    /// <param name="analyzerResult">The results from building a Buildalyzer project analyzer.</param>
+    /// <param name="addProjectReferences">
+    /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
+    /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
+    /// </param>
+    /// <returns>A Roslyn workspace.</returns>
+    public static AdhocWorkspace GetWorkspace(this IAnalyzerResult analyzerResult, bool addProjectReferences = false)
     {
-        /// <summary>
-        /// Gets a Roslyn workspace for the analyzed results.
-        /// </summary>
-        /// <param name="analyzerResult">The results from building a Buildalyzer project analyzer.</param>
-        /// <param name="addProjectReferences">
-        /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
-        /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
-        /// </param>
-        /// <returns>A Roslyn workspace.</returns>
-        public static AdhocWorkspace GetWorkspace(this IAnalyzerResult analyzerResult, bool addProjectReferences = false)
+        if (analyzerResult == null)
         {
-            if (analyzerResult == null)
-            {
-                throw new ArgumentNullException(nameof(analyzerResult));
-            }
-            AdhocWorkspace workspace = analyzerResult.Manager.CreateWorkspace();
-            analyzerResult.AddToWorkspace(workspace, addProjectReferences);
-            return workspace;
+            throw new ArgumentNullException(nameof(analyzerResult));
+        }
+        AdhocWorkspace workspace = analyzerResult.Manager.CreateWorkspace();
+        analyzerResult.AddToWorkspace(workspace, addProjectReferences);
+        return workspace;
+    }
+
+    /// <summary>
+    /// Adds a result to an existing Roslyn workspace.
+    /// </summary>
+    /// <param name="analyzerResult">The results from building a Buildalyzer project analyzer.</param>
+    /// <param name="workspace">A Roslyn workspace.</param>
+    /// <param name="addProjectReferences">
+    /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
+    /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
+    /// </param>
+    /// <returns>The newly added Roslyn project, or <c>null</c> if the project couldn't be added to the workspace.</returns>
+    public static Project AddToWorkspace(this IAnalyzerResult analyzerResult, Workspace workspace, bool addProjectReferences = false)
+    {
+        if (analyzerResult == null)
+        {
+            throw new ArgumentNullException(nameof(analyzerResult));
+        }
+        if (workspace == null)
+        {
+            throw new ArgumentNullException(nameof(workspace));
         }
 
-        /// <summary>
-        /// Adds a result to an existing Roslyn workspace.
-        /// </summary>
-        /// <param name="analyzerResult">The results from building a Buildalyzer project analyzer.</param>
-        /// <param name="workspace">A Roslyn workspace.</param>
-        /// <param name="addProjectReferences">
-        /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
-        /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
-        /// </param>
-        /// <returns>The newly added Roslyn project, or <c>null</c> if the project couldn't be added to the workspace.</returns>
-        public static Project AddToWorkspace(this IAnalyzerResult analyzerResult, Workspace workspace, bool addProjectReferences = false)
+        // Get or create an ID for this project
+        ProjectId projectId = ProjectId.CreateFromSerialized(analyzerResult.ProjectGuid);
+
+        // Cache the project references
+        analyzerResult.Manager.WorkspaceProjectReferences[projectId.Id] = analyzerResult.ProjectReferences.ToArray();
+
+        // Create and add the project, but only if it's a support Roslyn project type
+        ProjectInfo projectInfo = GetProjectInfo(analyzerResult, workspace, projectId);
+        if (projectInfo is null)
         {
-            if (analyzerResult == null)
-            {
-                throw new ArgumentNullException(nameof(analyzerResult));
-            }
-            if (workspace == null)
-            {
-                throw new ArgumentNullException(nameof(workspace));
-            }
+            // Something went wrong (maybe not a support project type), so don't add this project
+            return null;
+        }
+        Solution solution = workspace.CurrentSolution.AddProject(projectInfo);
 
-            // Get or create an ID for this project
-            ProjectId projectId = ProjectId.CreateFromSerialized(analyzerResult.ProjectGuid);
-
-            // Cache the project references
-            analyzerResult.Manager.WorkspaceProjectReferences[projectId.Id] = analyzerResult.ProjectReferences.ToArray();
-
-            // Create and add the project, but only if it's a support Roslyn project type
-            ProjectInfo projectInfo = GetProjectInfo(analyzerResult, workspace, projectId);
-            if (projectInfo is null)
+        // Check if this project is referenced by any other projects in the workspace
+        foreach (Project existingProject in solution.Projects.ToArray())
+        {
+            if (!existingProject.Id.Equals(projectId)
+                && analyzerResult.Manager.WorkspaceProjectReferences.TryGetValue(existingProject.Id.Id, out string[] existingReferences)
+                && existingReferences.Contains(analyzerResult.ProjectFilePath))
             {
-                // Something went wrong (maybe not a support project type), so don't add this project
-                return null;
+                // Add the reference to the existing project
+                ProjectReference projectReference = new ProjectReference(projectId);
+                solution = solution.AddProjectReference(existingProject.Id, projectReference);
             }
-            Solution solution = workspace.CurrentSolution.AddProject(projectInfo);
-
-            // Check if this project is referenced by any other projects in the workspace
-            foreach (Project existingProject in solution.Projects.ToArray())
-            {
-                if (!existingProject.Id.Equals(projectId)
-                    && analyzerResult.Manager.WorkspaceProjectReferences.TryGetValue(existingProject.Id.Id, out string[] existingReferences)
-                    && existingReferences.Contains(analyzerResult.ProjectFilePath))
-                {
-                    // Add the reference to the existing project
-                    ProjectReference projectReference = new ProjectReference(projectId);
-                    solution = solution.AddProjectReference(existingProject.Id, projectReference);
-                }
-            }
-
-            // Apply solution changes
-            if (!workspace.TryApplyChanges(solution))
-            {
-                throw new InvalidOperationException("Could not apply workspace solution changes");
-            }
-
-            // Add any project references not already added
-            if (addProjectReferences)
-            {
-                foreach (ProjectAnalyzer referencedAnalyzer in GetReferencedAnalyzerProjects(analyzerResult))
-                {
-                    // Check if the workspace contains the project inside the loop since adding one might also add this one due to transitive references
-                    if (!workspace.CurrentSolution.Projects.Any(x => x.FilePath == referencedAnalyzer.ProjectFile.Path))
-                    {
-                        referencedAnalyzer.AddToWorkspace(workspace, addProjectReferences);
-                    }
-                }
-            }
-
-            // By now all the references of this project have been recursively added, so resolve any remaining transitive project references
-            Project project = workspace.CurrentSolution.GetProject(projectId);
-            HashSet<ProjectReference> referencedProjects = new HashSet<ProjectReference>(project.ProjectReferences);
-            HashSet<ProjectId> visitedProjectIds = new HashSet<ProjectId>();
-            Stack<ProjectReference> projectReferenceStack = new Stack<ProjectReference>(project.ProjectReferences);
-            while (projectReferenceStack.Count > 0)
-            {
-                ProjectReference projectReference = projectReferenceStack.Pop();
-                Project nestedProject = workspace.CurrentSolution.GetProject(projectReference.ProjectId);
-                if (nestedProject is object && visitedProjectIds.Add(nestedProject.Id))
-                {
-                    foreach (ProjectReference nestedProjectReference in nestedProject.ProjectReferences)
-                    {
-                        projectReferenceStack.Push(nestedProjectReference);
-                        referencedProjects.Add(nestedProjectReference);
-                    }
-                }
-            }
-            foreach (ProjectReference referencedProject in referencedProjects)
-            {
-                if (!project.ProjectReferences.Contains(referencedProject))
-                {
-                    ProjectReference projectReference = new ProjectReference(referencedProject.ProjectId);
-                    solution = workspace.CurrentSolution.AddProjectReference(project.Id, projectReference);
-                    if (!workspace.TryApplyChanges(solution))
-                    {
-                        throw new InvalidOperationException("Could not apply workspace solution changes");
-                    }
-                }
-            }
-
-            // Find and return this project
-            return workspace.CurrentSolution.GetProject(projectId);
         }
 
-        private static ProjectInfo GetProjectInfo(IAnalyzerResult analyzerResult, Workspace workspace, ProjectId projectId)
+        // Apply solution changes
+        if (!workspace.TryApplyChanges(solution))
         {
-            string projectName = Path.GetFileNameWithoutExtension(analyzerResult.ProjectFilePath);
-            if (!TryGetSupportedLanguageName(analyzerResult.ProjectFilePath, out string languageName))
-            {
-                return null;
-            }
-            return ProjectInfo.Create(
-                projectId,
-                VersionStamp.Create(),
-                projectName,
-                projectName,
-                languageName,
-                filePath: analyzerResult.ProjectFilePath,
-                outputFilePath: analyzerResult.GetProperty("TargetPath"),
-                documents: GetDocuments(analyzerResult, projectId),
-                projectReferences: GetExistingProjectReferences(analyzerResult, workspace),
-                metadataReferences: GetMetadataReferences(analyzerResult),
-                analyzerReferences: GetAnalyzerReferences(analyzerResult, workspace),
-                additionalDocuments: GetAdditionalDocuments(analyzerResult, projectId),
-                parseOptions: CreateParseOptions(analyzerResult, languageName),
-                compilationOptions: CreateCompilationOptions(analyzerResult, languageName));
+            throw new InvalidOperationException("Could not apply workspace solution changes");
         }
 
-        private static ParseOptions CreateParseOptions(IAnalyzerResult analyzerResult, string languageName)
+        // Add any project references not already added
+        if (addProjectReferences)
+        {
+            foreach (ProjectAnalyzer referencedAnalyzer in GetReferencedAnalyzerProjects(analyzerResult))
+            {
+                // Check if the workspace contains the project inside the loop since adding one might also add this one due to transitive references
+                if (!workspace.CurrentSolution.Projects.Any(x => x.FilePath == referencedAnalyzer.ProjectFile.Path))
+                {
+                    referencedAnalyzer.AddToWorkspace(workspace, addProjectReferences);
+                }
+            }
+        }
+
+        // By now all the references of this project have been recursively added, so resolve any remaining transitive project references
+        Project project = workspace.CurrentSolution.GetProject(projectId);
+        HashSet<ProjectReference> referencedProjects = new HashSet<ProjectReference>(project.ProjectReferences);
+        HashSet<ProjectId> visitedProjectIds = new HashSet<ProjectId>();
+        Stack<ProjectReference> projectReferenceStack = new Stack<ProjectReference>(project.ProjectReferences);
+        while (projectReferenceStack.Count > 0)
+        {
+            ProjectReference projectReference = projectReferenceStack.Pop();
+            Project nestedProject = workspace.CurrentSolution.GetProject(projectReference.ProjectId);
+            if (nestedProject is object && visitedProjectIds.Add(nestedProject.Id))
+            {
+                foreach (ProjectReference nestedProjectReference in nestedProject.ProjectReferences)
+                {
+                    projectReferenceStack.Push(nestedProjectReference);
+                    referencedProjects.Add(nestedProjectReference);
+                }
+            }
+        }
+        foreach (ProjectReference referencedProject in referencedProjects)
+        {
+            if (!project.ProjectReferences.Contains(referencedProject))
+            {
+                ProjectReference projectReference = new ProjectReference(referencedProject.ProjectId);
+                solution = workspace.CurrentSolution.AddProjectReference(project.Id, projectReference);
+                if (!workspace.TryApplyChanges(solution))
+                {
+                    throw new InvalidOperationException("Could not apply workspace solution changes");
+                }
+            }
+        }
+
+        // Find and return this project
+        return workspace.CurrentSolution.GetProject(projectId);
+    }
+
+    private static ProjectInfo GetProjectInfo(IAnalyzerResult analyzerResult, Workspace workspace, ProjectId projectId)
+    {
+        string projectName = Path.GetFileNameWithoutExtension(analyzerResult.ProjectFilePath);
+        if (!TryGetSupportedLanguageName(analyzerResult.ProjectFilePath, out string languageName))
+        {
+            return null;
+        }
+        return ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            projectName,
+            projectName,
+            languageName,
+            filePath: analyzerResult.ProjectFilePath,
+            outputFilePath: analyzerResult.GetProperty("TargetPath"),
+            documents: GetDocuments(analyzerResult, projectId),
+            projectReferences: GetExistingProjectReferences(analyzerResult, workspace),
+            metadataReferences: GetMetadataReferences(analyzerResult),
+            analyzerReferences: GetAnalyzerReferences(analyzerResult, workspace),
+            additionalDocuments: GetAdditionalDocuments(analyzerResult, projectId),
+            parseOptions: CreateParseOptions(analyzerResult, languageName),
+            compilationOptions: CreateCompilationOptions(analyzerResult, languageName));
+    }
+
+    private static ParseOptions CreateParseOptions(IAnalyzerResult analyzerResult, string languageName)
+    {
+        // language-specific code is in local functions, to prevent assembly loading failures when assembly for the other language is not available
+        if (languageName == LanguageNames.CSharp)
+        {
+            ParseOptions CreateCSharpParseOptions()
+            {
+                CSharpParseOptions parseOptions = new CSharpParseOptions();
+
+                // Add any constants
+                parseOptions = parseOptions.WithPreprocessorSymbols(analyzerResult.PreprocessorSymbols);
+
+                // Get language version
+                string langVersion = analyzerResult.GetProperty("LangVersion");
+                if (!string.IsNullOrWhiteSpace(langVersion)
+                    && Microsoft.CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(langVersion, out Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion))
+                {
+                    parseOptions = parseOptions.WithLanguageVersion(languageVersion);
+                }
+
+                return parseOptions;
+            }
+
+            return CreateCSharpParseOptions();
+        }
+
+        if (languageName == LanguageNames.VisualBasic)
+        {
+            ParseOptions CreateVBParseOptions()
+            {
+                VisualBasicParseOptions parseOptions = new VisualBasicParseOptions();
+
+                // Get language version
+                string langVersion = analyzerResult.GetProperty("LangVersion");
+                Microsoft.CodeAnalysis.VisualBasic.LanguageVersion languageVersion = Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.Default;
+                if (!string.IsNullOrWhiteSpace(langVersion)
+                    && Microsoft.CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(langVersion, ref languageVersion))
+                {
+                    parseOptions = parseOptions.WithLanguageVersion(languageVersion);
+                }
+
+                return parseOptions;
+            }
+
+            return CreateVBParseOptions();
+        }
+
+        return null;
+    }
+
+    private static CompilationOptions CreateCompilationOptions(IAnalyzerResult analyzerResult, string languageName)
+    {
+        string outputType = analyzerResult.GetProperty("OutputType");
+        OutputKind? kind = null;
+        switch (outputType)
+        {
+            case "Library":
+                kind = OutputKind.DynamicallyLinkedLibrary;
+                break;
+            case "Exe":
+                kind = OutputKind.ConsoleApplication;
+                break;
+            case "Module":
+                kind = OutputKind.NetModule;
+                break;
+            case "Winexe":
+                kind = OutputKind.WindowsApplication;
+                break;
+        }
+
+        if (kind.HasValue)
         {
             // language-specific code is in local functions, to prevent assembly loading failures when assembly for the other language is not available
             if (languageName == LanguageNames.CSharp)
             {
-                ParseOptions CreateCSharpParseOptions()
-                {
-                    CSharpParseOptions parseOptions = new CSharpParseOptions();
+                Enum.TryParse(analyzerResult.GetProperty("Nullable"), ignoreCase: true, out NullableContextOptions nullable);
 
-                    // Add any constants
-                    parseOptions = parseOptions.WithPreprocessorSymbols(analyzerResult.PreprocessorSymbols);
+                CompilationOptions CreateCSharpCompilationOptions() => new CSharpCompilationOptions(kind.Value, nullableContextOptions: nullable);
 
-                    // Get language version
-                    string langVersion = analyzerResult.GetProperty("LangVersion");
-                    if (!string.IsNullOrWhiteSpace(langVersion)
-                        && Microsoft.CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(langVersion, out Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion))
-                    {
-                        parseOptions = parseOptions.WithLanguageVersion(languageVersion);
-                    }
-
-                    return parseOptions;
-                }
-
-                return CreateCSharpParseOptions();
+                return CreateCSharpCompilationOptions();
             }
 
             if (languageName == LanguageNames.VisualBasic)
             {
-                ParseOptions CreateVBParseOptions()
-                {
-                    VisualBasicParseOptions parseOptions = new VisualBasicParseOptions();
+                CompilationOptions CreateVBCompilationOptions() => new VisualBasicCompilationOptions(kind.Value);
 
-                    // Get language version
-                    string langVersion = analyzerResult.GetProperty("LangVersion");
-                    Microsoft.CodeAnalysis.VisualBasic.LanguageVersion languageVersion = Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.Default;
-                    if (!string.IsNullOrWhiteSpace(langVersion)
-                        && Microsoft.CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(langVersion, ref languageVersion))
-                    {
-                        parseOptions = parseOptions.WithLanguageVersion(languageVersion);
-                    }
-
-                    return parseOptions;
-                }
-
-                return CreateVBParseOptions();
+                return CreateVBCompilationOptions();
             }
-
-            return null;
         }
 
-        private static CompilationOptions CreateCompilationOptions(IAnalyzerResult analyzerResult, string languageName)
+        return null;
+    }
+
+    private static IEnumerable<ProjectReference> GetExistingProjectReferences(IAnalyzerResult analyzerResult, Workspace workspace) =>
+        analyzerResult.ProjectReferences
+            .Select(x => workspace.CurrentSolution.Projects.FirstOrDefault(y => y.FilePath.Equals(x, StringComparison.OrdinalIgnoreCase)))
+
+            .Where(x => x != null)
+            .Select(x => new ProjectReference(x.Id))
+        ?? Array.Empty<ProjectReference>();
+
+    private static IEnumerable<IProjectAnalyzer> GetReferencedAnalyzerProjects(IAnalyzerResult analyzerResult) =>
+        analyzerResult.ProjectReferences
+            .Select(x => analyzerResult.Manager.Projects.TryGetValue(x, out IProjectAnalyzer a) ? a : analyzerResult.Manager.GetProject(x))
+            .Where(x => x != null)
+        ?? Array.Empty<ProjectAnalyzer>();
+
+    private static IEnumerable<DocumentInfo> GetDocuments(IAnalyzerResult analyzerResult, ProjectId projectId)
+    {
+        string[] sourceFiles = analyzerResult.SourceFiles ?? Array.Empty<string>();
+        return GetDocuments(sourceFiles, projectId);
+    }
+
+    private static IEnumerable<DocumentInfo> GetDocuments(IEnumerable<string> files, ProjectId projectId) =>
+       files.Where(File.Exists)
+           .Select(x => DocumentInfo.Create(
+               DocumentId.CreateNewId(projectId),
+               Path.GetFileName(x),
+               loader: TextLoader.From(
+                   TextAndVersion.Create(
+                       SourceText.From(File.ReadAllText(x), Encoding.Unicode), VersionStamp.Create())),
+               filePath: x));
+
+    private static IEnumerable<DocumentInfo> GetAdditionalDocuments(IAnalyzerResult analyzerResult, ProjectId projectId)
+    {
+        string projectDirectory = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
+        string[] additionalFiles = analyzerResult.AdditionalFiles ?? Array.Empty<string>();
+        return GetDocuments(additionalFiles.Select(x => Path.Combine(projectDirectory!, x)), projectId);
+    }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences(IAnalyzerResult analyzerResult) =>
+        analyzerResult
+            .References?.Where(File.Exists)
+            .Select(x => MetadataReference.CreateFromFile(x))
+        ?? (IEnumerable<MetadataReference>)Array.Empty<MetadataReference>();
+
+    private static IEnumerable<AnalyzerReference> GetAnalyzerReferences(IAnalyzerResult analyzerResult, Workspace workspace)
+    {
+        IAnalyzerAssemblyLoader loader = workspace.Services.GetRequiredService<IAnalyzerService>().GetLoader();
+
+        string projectDirectory = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
+        return analyzerResult.AnalyzerReferences?.Where(x => File.Exists(Path.GetFullPath(x, projectDirectory!)))
+            .Select(x => new AnalyzerFileReference(Path.GetFullPath(x, projectDirectory!), loader))
+            ?? (IEnumerable<AnalyzerReference>)Array.Empty<AnalyzerReference>();
+    }
+
+    private static bool TryGetSupportedLanguageName(string projectPath, out string languageName)
+    {
+        switch (Path.GetExtension(projectPath))
         {
-            string outputType = analyzerResult.GetProperty("OutputType");
-            OutputKind? kind = null;
-            switch (outputType)
-            {
-                case "Library":
-                    kind = OutputKind.DynamicallyLinkedLibrary;
-                    break;
-                case "Exe":
-                    kind = OutputKind.ConsoleApplication;
-                    break;
-                case "Module":
-                    kind = OutputKind.NetModule;
-                    break;
-                case "Winexe":
-                    kind = OutputKind.WindowsApplication;
-                    break;
-            }
-
-            if (kind.HasValue)
-            {
-                // language-specific code is in local functions, to prevent assembly loading failures when assembly for the other language is not available
-                if (languageName == LanguageNames.CSharp)
-                {
-                    Enum.TryParse(analyzerResult.GetProperty("Nullable"), ignoreCase: true, out NullableContextOptions nullable);
-
-                    CompilationOptions CreateCSharpCompilationOptions() => new CSharpCompilationOptions(kind.Value, nullableContextOptions: nullable);
-
-                    return CreateCSharpCompilationOptions();
-                }
-
-                if (languageName == LanguageNames.VisualBasic)
-                {
-                    CompilationOptions CreateVBCompilationOptions() => new VisualBasicCompilationOptions(kind.Value);
-
-                    return CreateVBCompilationOptions();
-                }
-            }
-
-            return null;
-        }
-
-        private static IEnumerable<ProjectReference> GetExistingProjectReferences(IAnalyzerResult analyzerResult, Workspace workspace) =>
-            analyzerResult.ProjectReferences
-                .Select(x => workspace.CurrentSolution.Projects.FirstOrDefault(y => y.FilePath.Equals(x, StringComparison.OrdinalIgnoreCase)))
-
-                .Where(x => x != null)
-                .Select(x => new ProjectReference(x.Id))
-            ?? Array.Empty<ProjectReference>();
-
-        private static IEnumerable<IProjectAnalyzer> GetReferencedAnalyzerProjects(IAnalyzerResult analyzerResult) =>
-            analyzerResult.ProjectReferences
-                .Select(x => analyzerResult.Manager.Projects.TryGetValue(x, out IProjectAnalyzer a) ? a : analyzerResult.Manager.GetProject(x))
-                .Where(x => x != null)
-            ?? Array.Empty<ProjectAnalyzer>();
-
-        private static IEnumerable<DocumentInfo> GetDocuments(IAnalyzerResult analyzerResult, ProjectId projectId)
-        {
-            string[] sourceFiles = analyzerResult.SourceFiles ?? Array.Empty<string>();
-            return GetDocuments(sourceFiles, projectId);
-        }
-
-        private static IEnumerable<DocumentInfo> GetDocuments(IEnumerable<string> files, ProjectId projectId) =>
-           files.Where(File.Exists)
-               .Select(x => DocumentInfo.Create(
-                   DocumentId.CreateNewId(projectId),
-                   Path.GetFileName(x),
-                   loader: TextLoader.From(
-                       TextAndVersion.Create(
-                           SourceText.From(File.ReadAllText(x), Encoding.Unicode), VersionStamp.Create())),
-                   filePath: x));
-
-        private static IEnumerable<DocumentInfo> GetAdditionalDocuments(IAnalyzerResult analyzerResult, ProjectId projectId)
-        {
-            string projectDirectory = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
-            string[] additionalFiles = analyzerResult.AdditionalFiles ?? Array.Empty<string>();
-            return GetDocuments(additionalFiles.Select(x => Path.Combine(projectDirectory!, x)), projectId);
-        }
-
-        private static IEnumerable<MetadataReference> GetMetadataReferences(IAnalyzerResult analyzerResult) =>
-            analyzerResult
-                .References?.Where(File.Exists)
-                .Select(x => MetadataReference.CreateFromFile(x))
-            ?? (IEnumerable<MetadataReference>)Array.Empty<MetadataReference>();
-
-        private static IEnumerable<AnalyzerReference> GetAnalyzerReferences(IAnalyzerResult analyzerResult, Workspace workspace)
-        {
-            IAnalyzerAssemblyLoader loader = workspace.Services.GetRequiredService<IAnalyzerService>().GetLoader();
-
-            string projectDirectory = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
-            return analyzerResult.AnalyzerReferences?.Where(x => File.Exists(Path.GetFullPath(x, projectDirectory!)))
-                .Select(x => new AnalyzerFileReference(Path.GetFullPath(x, projectDirectory!), loader))
-                ?? (IEnumerable<AnalyzerReference>)Array.Empty<AnalyzerReference>();
-        }
-
-        private static bool TryGetSupportedLanguageName(string projectPath, out string languageName)
-        {
-            switch (Path.GetExtension(projectPath))
-            {
-                case ".csproj":
-                    languageName = LanguageNames.CSharp;
-                    return true;
-                case ".vbproj":
-                    languageName = LanguageNames.VisualBasic;
-                    return true;
-                default:
-                    languageName = null;
-                    return false;
-            }
+            case ".csproj":
+                languageName = LanguageNames.CSharp;
+                return true;
+            case ".vbproj":
+                languageName = LanguageNames.VisualBasic;
+                return true;
+            default:
+                languageName = null;
+                return false;
         }
     }
 }

--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <Description>A little utility to perform design-time builds of .NET projects without having to think too hard about it. This extension library adds support for creating a Roslyn workspace from Buildalyzer.</Description>
   </PropertyGroup>
 

--- a/src/Buildalyzer.Workspaces/ProjectAnalyzerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/ProjectAnalyzerExtensions.cs
@@ -1,60 +1,52 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using Microsoft.Build.Execution;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.VisualBasic;
 
-namespace Buildalyzer.Workspaces
+namespace Buildalyzer.Workspaces;
+
+public static class ProjectAnalyzerExtensions
 {
-    public static class ProjectAnalyzerExtensions
+    /// <summary>
+    /// Gets a Roslyn workspace for the analyzed project. Note that this will rebuild the project. Use an <see cref="AnalyzerResult"/> instead if you already have one available.
+    /// </summary>
+    /// <param name="analyzer">The Buildalyzer project analyzer.</param>
+    /// <param name="addProjectReferences">
+    /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
+    /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
+    /// </param>
+    /// <returns>A Roslyn workspace.</returns>
+    public static AdhocWorkspace GetWorkspace(this IProjectAnalyzer analyzer, bool addProjectReferences = false)
     {
-        /// <summary>
-        /// Gets a Roslyn workspace for the analyzed project. Note that this will rebuild the project. Use an <see cref="AnalyzerResult"/> instead if you already have one available.
-        /// </summary>
-        /// <param name="analyzer">The Buildalyzer project analyzer.</param>
-        /// <param name="addProjectReferences">
-        /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
-        /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
-        /// </param>
-        /// <returns>A Roslyn workspace.</returns>
-        public static AdhocWorkspace GetWorkspace(this IProjectAnalyzer analyzer, bool addProjectReferences = false)
+        if (analyzer == null)
         {
-            if (analyzer == null)
-            {
-                throw new ArgumentNullException(nameof(analyzer));
-            }
-            AdhocWorkspace workspace = analyzer.Manager.CreateWorkspace();
-            AddToWorkspace(analyzer, workspace, addProjectReferences);
-            return workspace;
+            throw new ArgumentNullException(nameof(analyzer));
+        }
+        AdhocWorkspace workspace = analyzer.Manager.CreateWorkspace();
+        AddToWorkspace(analyzer, workspace, addProjectReferences);
+        return workspace;
+    }
+
+    /// <summary>
+    /// Adds a project to an existing Roslyn workspace. Note that this will rebuild the project. Use an <see cref="AnalyzerResult"/> instead if you already have one available.
+    /// </summary>
+    /// <param name="analyzer">The Buildalyzer project analyzer.</param>
+    /// <param name="workspace">A Roslyn workspace.</param>
+    /// <param name="addProjectReferences">
+    /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
+    /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
+    /// </param>
+    /// <returns>The newly added Roslyn project.</returns>
+    public static Project AddToWorkspace(this IProjectAnalyzer analyzer, Workspace workspace, bool addProjectReferences = false)
+    {
+        if (analyzer == null)
+        {
+            throw new ArgumentNullException(nameof(analyzer));
+        }
+        if (workspace == null)
+        {
+            throw new ArgumentNullException(nameof(workspace));
         }
 
-        /// <summary>
-        /// Adds a project to an existing Roslyn workspace. Note that this will rebuild the project. Use an <see cref="AnalyzerResult"/> instead if you already have one available.
-        /// </summary>
-        /// <param name="analyzer">The Buildalyzer project analyzer.</param>
-        /// <param name="workspace">A Roslyn workspace.</param>
-        /// <param name="addProjectReferences">
-        /// <c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.
-        /// If <c>true</c> this will trigger (re)building all referenced projects. Directly add <see cref="AnalyzerResult"/> instances instead if you already have them available.
-        /// </param>
-        /// <returns>The newly added Roslyn project.</returns>
-        public static Project AddToWorkspace(this IProjectAnalyzer analyzer, Workspace workspace, bool addProjectReferences = false)
-        {
-            if (analyzer == null)
-            {
-                throw new ArgumentNullException(nameof(analyzer));
-            }
-            if (workspace == null)
-            {
-                throw new ArgumentNullException(nameof(workspace));
-            }
-
-            return analyzer.Build().FirstOrDefault().AddToWorkspace(workspace, addProjectReferences);
-        }
+        return analyzer.Build().FirstOrDefault().AddToWorkspace(workspace, addProjectReferences);
     }
 }

--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -10,125 +10,124 @@ using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
 using StructuredLogger::Microsoft.Build.Logging.StructuredLogger;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class AnalyzerManager : IAnalyzerManager
 {
-    public class AnalyzerManager : IAnalyzerManager
+    internal static readonly SolutionProjectType[] SupportedProjectTypes = new SolutionProjectType[]
     {
-        internal static readonly SolutionProjectType[] SupportedProjectTypes = new SolutionProjectType[]
-        {
-            SolutionProjectType.KnownToBeMSBuildFormat,
-            SolutionProjectType.WebProject
-        };
+        SolutionProjectType.KnownToBeMSBuildFormat,
+        SolutionProjectType.WebProject
+    };
 
-        private readonly ConcurrentDictionary<string, IProjectAnalyzer> _projects = new ConcurrentDictionary<string, IProjectAnalyzer>();
+    private readonly ConcurrentDictionary<string, IProjectAnalyzer> _projects = new ConcurrentDictionary<string, IProjectAnalyzer>();
 
-        public IReadOnlyDictionary<string, IProjectAnalyzer> Projects => _projects;
+    public IReadOnlyDictionary<string, IProjectAnalyzer> Projects => _projects;
 
-        public ILoggerFactory LoggerFactory { get; set; }
+    public ILoggerFactory LoggerFactory { get; set; }
 
-        internal ConcurrentDictionary<string, string> GlobalProperties { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    internal ConcurrentDictionary<string, string> GlobalProperties { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        internal ConcurrentDictionary<string, string> EnvironmentVariables { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    internal ConcurrentDictionary<string, string> EnvironmentVariables { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        /// <summary>
-        /// This maps Roslyn project IDs to full normalized project file paths of references (since the Roslyn Project doesn't provide access to this data)
-        /// which allows us to match references with Roslyn projects that already exist in the Workspace/Solution (instead of rebuilding them).
-        /// This cache exists in <see cref="AnalyzerManager"/> so that it's lifetime can be controlled and it can be collected when <see cref="AnalyzerManager"/> goes out of scope.
-        /// </summary>
+    /// <summary>
+    /// This maps Roslyn project IDs to full normalized project file paths of references (since the Roslyn Project doesn't provide access to this data)
+    /// which allows us to match references with Roslyn projects that already exist in the Workspace/Solution (instead of rebuilding them).
+    /// This cache exists in <see cref="AnalyzerManager"/> so that it's lifetime can be controlled and it can be collected when <see cref="AnalyzerManager"/> goes out of scope.
+    /// </summary>
 #pragma warning disable SA1401 // Fields should be private
-        internal ConcurrentDictionary<Guid, string[]> WorkspaceProjectReferences = new ConcurrentDictionary<Guid, string[]>();
+    internal ConcurrentDictionary<Guid, string[]> WorkspaceProjectReferences = new ConcurrentDictionary<Guid, string[]>();
 #pragma warning restore SA1401 // Fields should be private
 
-        public string SolutionFilePath { get; }
+    public string SolutionFilePath { get; }
 
-        public SolutionFile SolutionFile { get; }
+    public SolutionFile SolutionFile { get; }
 
-        public AnalyzerManager(AnalyzerManagerOptions options = null)
-            : this(null, options)
-        {
-        }
-
-        public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions options = null)
-        {
-            options = options ?? new AnalyzerManagerOptions();
-            LoggerFactory = options.LoggerFactory;
-
-            if (!string.IsNullOrEmpty(solutionFilePath))
-            {
-                SolutionFilePath = NormalizePath(solutionFilePath);
-                SolutionFile = SolutionFile.Parse(SolutionFilePath);
-
-                // Initialize all the projects in the solution
-                foreach (ProjectInSolution projectInSolution in SolutionFile.ProjectsInOrder)
-                {
-                    if (!SupportedProjectTypes.Contains(projectInSolution.ProjectType)
-                        || (options?.ProjectFilter != null && !options.ProjectFilter(projectInSolution)))
-                    {
-                        continue;
-                    }
-                    GetProject(projectInSolution.AbsolutePath, projectInSolution);
-                }
-            }
-        }
-
-        public void SetGlobalProperty(string key, string value)
-        {
-            GlobalProperties[key] = value;
-        }
-
-        public void RemoveGlobalProperty(string key)
-        {
-            // Nulls are removed before passing to MSBuild and can be used to ignore values in lower-precedence collections
-            GlobalProperties[key] = null;
-        }
-
-        public void SetEnvironmentVariable(string key, string value)
-        {
-            EnvironmentVariables[key] = value;
-        }
-
-        public IProjectAnalyzer GetProject(string projectFilePath) => GetProject(projectFilePath, null);
-
-        /// <inheritdoc/>
-        public IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null)
-        {
-            binLogPath = NormalizePath(binLogPath);
-            if (!File.Exists(binLogPath))
-            {
-                throw new ArgumentException($"The path {binLogPath} could not be found.");
-            }
-
-            BinLogReader reader = new BinLogReader();
-            using (EventProcessor eventProcessor = new EventProcessor(this, null, buildLoggers, reader, true))
-            {
-                reader.Replay(binLogPath);
-                return new AnalyzerResults
-                {
-                    { eventProcessor.Results, eventProcessor.OverallSuccess }
-                };
-            }
-        }
-
-        private IProjectAnalyzer GetProject(string projectFilePath, ProjectInSolution projectInSolution)
-        {
-            if (projectFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(projectFilePath));
-            }
-
-            projectFilePath = NormalizePath(projectFilePath);
-            if (!File.Exists(projectFilePath))
-            {
-                if (projectInSolution == null)
-                {
-                    throw new ArgumentException($"The path {projectFilePath} could not be found.");
-                }
-                return null;
-            }
-            return _projects.GetOrAdd(projectFilePath, new ProjectAnalyzer(this, projectFilePath, projectInSolution));
-        }
-
-        internal static string NormalizePath(string path) =>
-            path == null ? null : Path.GetFullPath(path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar));
+    public AnalyzerManager(AnalyzerManagerOptions options = null)
+        : this(null, options)
+    {
     }
+
+    public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions options = null)
+    {
+        options = options ?? new AnalyzerManagerOptions();
+        LoggerFactory = options.LoggerFactory;
+
+        if (!string.IsNullOrEmpty(solutionFilePath))
+        {
+            SolutionFilePath = NormalizePath(solutionFilePath);
+            SolutionFile = SolutionFile.Parse(SolutionFilePath);
+
+            // Initialize all the projects in the solution
+            foreach (ProjectInSolution projectInSolution in SolutionFile.ProjectsInOrder)
+            {
+                if (!SupportedProjectTypes.Contains(projectInSolution.ProjectType)
+                    || (options?.ProjectFilter != null && !options.ProjectFilter(projectInSolution)))
+                {
+                    continue;
+                }
+                GetProject(projectInSolution.AbsolutePath, projectInSolution);
+            }
+        }
+    }
+
+    public void SetGlobalProperty(string key, string value)
+    {
+        GlobalProperties[key] = value;
+    }
+
+    public void RemoveGlobalProperty(string key)
+    {
+        // Nulls are removed before passing to MSBuild and can be used to ignore values in lower-precedence collections
+        GlobalProperties[key] = null;
+    }
+
+    public void SetEnvironmentVariable(string key, string value)
+    {
+        EnvironmentVariables[key] = value;
+    }
+
+    public IProjectAnalyzer GetProject(string projectFilePath) => GetProject(projectFilePath, null);
+
+    /// <inheritdoc/>
+    public IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null)
+    {
+        binLogPath = NormalizePath(binLogPath);
+        if (!File.Exists(binLogPath))
+        {
+            throw new ArgumentException($"The path {binLogPath} could not be found.");
+        }
+
+        BinLogReader reader = new BinLogReader();
+        using (EventProcessor eventProcessor = new EventProcessor(this, null, buildLoggers, reader, true))
+        {
+            reader.Replay(binLogPath);
+            return new AnalyzerResults
+            {
+                { eventProcessor.Results, eventProcessor.OverallSuccess }
+            };
+        }
+    }
+
+    private IProjectAnalyzer GetProject(string projectFilePath, ProjectInSolution projectInSolution)
+    {
+        if (projectFilePath == null)
+        {
+            throw new ArgumentNullException(nameof(projectFilePath));
+        }
+
+        projectFilePath = NormalizePath(projectFilePath);
+        if (!File.Exists(projectFilePath))
+        {
+            if (projectInSolution == null)
+            {
+                throw new ArgumentException($"The path {projectFilePath} could not be found.");
+            }
+            return null;
+        }
+        return _projects.GetOrAdd(projectFilePath, new ProjectAnalyzer(this, projectFilePath, projectInSolution));
+    }
+
+    internal static string NormalizePath(string path) =>
+        path == null ? null : Path.GetFullPath(path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar));
 }

--- a/src/Buildalyzer/AnalyzerManagerOptions.cs
+++ b/src/Buildalyzer/AnalyzerManagerOptions.cs
@@ -1,36 +1,33 @@
 ﻿using System;
 using System.IO;
-using Buildalyzer.Construction;
 using Buildalyzer.Logging;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class AnalyzerManagerOptions
 {
-    public class AnalyzerManagerOptions
+    public ILoggerFactory LoggerFactory { get; set; }
+
+    /// <summary>
+    /// A filter that indicates whether a give project should be loaded.
+    /// Return <c>true</c> to load the project, <c>false</c> to filter it out.
+    /// </summary>
+    public Func<ProjectInSolution, bool> ProjectFilter { get; set; }
+
+    public TextWriter LogWriter
     {
-        public ILoggerFactory LoggerFactory { get; set; }
-
-        /// <summary>
-        /// A filter that indicates whether a give project should be loaded.
-        /// Return <c>true</c> to load the project, <c>false</c> to filter it out.
-        /// </summary>
-        public Func<ProjectInSolution, bool> ProjectFilter { get; set; }
-
-        public TextWriter LogWriter
+        set
         {
-            set
+            if (value == null)
             {
-                if (value == null)
-                {
-                    LoggerFactory = null;
-                    return;
-                }
-
-                LoggerFactory = LoggerFactory ?? new LoggerFactory();
-                LoggerFactory.AddProvider(new TextWriterLoggerProvider(value));
+                LoggerFactory = null;
+                return;
             }
+
+            LoggerFactory = LoggerFactory ?? new LoggerFactory();
+            LoggerFactory.AddProvider(new TextWriterLoggerProvider(value));
         }
     }
 }

--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -8,468 +8,467 @@ using Buildalyzer.Construction;
 using Buildalyzer.Logging;
 using Microsoft.Build.Framework;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class AnalyzerResult : IAnalyzerResult
 {
-    public class AnalyzerResult : IAnalyzerResult
+    private readonly Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, IProjectItem[]> _items = new Dictionary<string, IProjectItem[]>(StringComparer.OrdinalIgnoreCase);
+    private readonly Guid _projectGuid;
+    private readonly List<string> _assemblyObjects = new List<string>
     {
-        private readonly Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, IProjectItem[]> _items = new Dictionary<string, IProjectItem[]>(StringComparer.OrdinalIgnoreCase);
-        private readonly Guid _projectGuid;
-        private readonly List<string> _assemblyObjects = new List<string>
-        {
-            "vbc.exe",
-            "vbc.dll",
-            "csc.exe",
-            "csc.dll",
-            "fsc.exe",
-            "fsc.dll"
-        };
-        private List<(string, string)> _cscCommandLineArguments;
-        private List<(string, string)> _fscCommandLineArguments;
-        private List<(string, string)> _vbcCommandLineArguments;
-        private string _command;
-        private string[] _compilerArguments;
-        private string _compilerFilePath;
+        "vbc.exe",
+        "vbc.dll",
+        "csc.exe",
+        "csc.dll",
+        "fsc.exe",
+        "fsc.dll"
+    };
+    private List<(string, string)> _cscCommandLineArguments;
+    private List<(string, string)> _fscCommandLineArguments;
+    private List<(string, string)> _vbcCommandLineArguments;
+    private string _command;
+    private string[] _compilerArguments;
+    private string _compilerFilePath;
 
-        internal AnalyzerResult(string projectFilePath, AnalyzerManager manager, ProjectAnalyzer analyzer)
-        {
-            ProjectFilePath = projectFilePath;
-            Manager = manager;
-            Analyzer = analyzer;
+    internal AnalyzerResult(string projectFilePath, AnalyzerManager manager, ProjectAnalyzer analyzer)
+    {
+        ProjectFilePath = projectFilePath;
+        Manager = manager;
+        Analyzer = analyzer;
 
-            string projectGuid = GetProperty(nameof(ProjectGuid));
-            if (string.IsNullOrEmpty(projectGuid) || !Guid.TryParse(projectGuid, out _projectGuid))
+        string projectGuid = GetProperty(nameof(ProjectGuid));
+        if (string.IsNullOrEmpty(projectGuid) || !Guid.TryParse(projectGuid, out _projectGuid))
+        {
+            _projectGuid = analyzer == null
+                ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFilePath)
+                : analyzer.ProjectGuid;
+        }
+    }
+
+    /// <inheritdoc/>
+    public string ProjectFilePath { get; }
+
+    public AnalyzerManager Manager { get; }
+
+    /// <inheritdoc/>
+    public ProjectAnalyzer Analyzer { get; }
+
+    public bool Succeeded { get; internal set; }
+
+    public IReadOnlyDictionary<string, string> Properties => _properties;
+
+    public IReadOnlyDictionary<string, IProjectItem[]> Items => _items;
+
+    /// <inheritdoc/>
+    public Guid ProjectGuid => _projectGuid;
+
+    /// <inheritdoc/>
+    public string Command => _command;
+
+    /// <inheritdoc/>
+    public string CompilerFilePath => _compilerFilePath;
+
+    /// <inheritdoc/>
+    public string[] CompilerArguments => _compilerArguments;
+
+    /// <inheritdoc/>
+    public string GetProperty(string name) =>
+        Properties.TryGetValue(name, out string value) ? value : null;
+
+    public string TargetFramework =>
+        ProjectFile.GetTargetFrameworks(
+            null,  // Don't want all target frameworks since the result is just for one
+            new[] { GetProperty(ProjectFileNames.TargetFramework) },
+            new[] { (GetProperty(ProjectFileNames.TargetFrameworkIdentifier), GetProperty(ProjectFileNames.TargetFrameworkVersion)) })
+        .FirstOrDefault();
+
+    public string[] SourceFiles =>
+        _cscCommandLineArguments
+            ?.Where(x => x.Item1 == null
+                && !string.Equals(Path.GetFileName(x.Item2), "csc.dll", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(Path.GetFileName(x.Item2), "csc.exe", StringComparison.OrdinalIgnoreCase))
+            .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
+            .ToArray() ?? _fscCommandLineArguments
+            ?.Where(x => x.Item1 == null
+                && x.Item2?.Contains("fsc.dll") == false
+                && x.Item2?.Contains("fsc.exe") == false)
+            .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
+            .ToArray() ?? _vbcCommandLineArguments
+            ?.Where(x => x.Item1 == null && !_assemblyObjects.Contains(Path.GetFileName(x.Item2), StringComparer.OrdinalIgnoreCase))
+            .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
+            .ToArray() ?? Array.Empty<string>();
+
+    public string[] References =>
+        _cscCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("reference", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Item2)
+            .ToArray()
+        ?? _fscCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("r", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Item2)
+            .ToArray()
+        ?? _vbcCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("reference", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Item2)
+            .ToArray()
+        ?? Array.Empty<string>();
+
+    public string[] AnalyzerReferences =>
+        _cscCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("analyzer", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Item2)
+            .ToArray() ?? Array.Empty<string>();
+
+    public string[] PreprocessorSymbols =>
+        _cscCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("define", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            .Select(x => x.Trim())
+            .ToArray()
+        ?? _vbcCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("define", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            .Select(x => x.Trim())
+            .ToArray()
+        ?? Array.Empty<string>();
+
+    public string[] AdditionalFiles =>
+        _cscCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("additionalfile", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            .Select(x => x.Trim())
+            .ToArray()
+        ?? _vbcCommandLineArguments
+            ?.Where(x => x.Item1 is object && x.Item1.Equals("additionalfile", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            .Select(x => x.Trim())
+            .ToArray()
+        ?? Array.Empty<string>();
+
+    public IEnumerable<string> ProjectReferences =>
+        Items.TryGetValue("ProjectReference", out IProjectItem[] items)
+            ? items.Distinct(new ProjectItemItemSpecEqualityComparer())
+                   .Select(x => AnalyzerManager.NormalizePath(
+                        Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.ItemSpec)))
+            : Array.Empty<string>();
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences =>
+        Items.TryGetValue("PackageReference", out IProjectItem[] items)
+            ? items.Distinct(new ProjectItemItemSpecEqualityComparer()).ToDictionary(x => x.ItemSpec, x => x.Metadata)
+            : new Dictionary<string, IReadOnlyDictionary<string, string>>();
+
+    internal void ProcessProject(PropertiesAndItems propertiesAndItems)
+    {
+        // Add properties
+        foreach (DictionaryEntry entry in propertiesAndItems.Properties.ToDictionaryEntries())
+        {
+            _properties[entry.Key.ToString()] = entry.Value.ToString();
+        }
+
+        // Add items
+        foreach (IGrouping<string, DictionaryEntry> itemGroup in propertiesAndItems.Items.ToDictionaryEntries().GroupBy(x => x.Key.ToString()))
+        {
+            _items[itemGroup.Key] = itemGroup.Select(x => new ProjectItem((ITaskItem)x.Value)).ToArray();
+        }
+    }
+
+    internal void ProcessCscCommandLine(string commandLine, bool coreCompile)
+    {
+        // Some projects can have multiple Csc calls (see #92) so if this is the one inside CoreCompile use it, otherwise use the first
+        if (string.IsNullOrWhiteSpace(commandLine) || (_cscCommandLineArguments != null && !coreCompile))
+        {
+            return;
+        }
+        ProcessedCommandLine cmd = ProcessCscCommandLine(commandLine);
+        _command = cmd.Command;
+        _compilerFilePath = cmd.FileName;
+        _compilerArguments = cmd.Arguments.ToArray();
+        _cscCommandLineArguments = cmd.ProcessedArguments;
+    }
+
+    internal static ProcessedCommandLine ProcessCscCommandLine(string commandLine)
+    {
+        return ProcessCommandLine(commandLine, "csc.");
+    }
+
+    internal struct ProcessedCommandLine
+    {
+        public string Command;
+        public string FileName;
+        public List<string> Arguments;
+        public List<(string, string)> ProcessedArguments;
+    }
+
+    internal static ProcessedCommandLine ProcessCommandLine(string commandLine, string initialCommandEnd)
+    {
+        ProcessedCommandLine cmd;
+        cmd.Command = commandLine;
+        cmd.FileName = string.Empty;
+        cmd.Arguments = new List<string>();
+        cmd.ProcessedArguments = new List<(string, string)>();
+
+        using (IEnumerator<string> enumerator = EnumerateCommandLineParts(commandLine, initialCommandEnd).GetEnumerator())
+        {
+            if (!enumerator.MoveNext())
             {
-                _projectGuid = analyzer == null
-                    ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFilePath)
-                    : analyzer.ProjectGuid;
+                return cmd;
             }
-        }
 
-        /// <inheritdoc/>
-        public string ProjectFilePath { get; }
+            // Initial command (csc)
+            cmd.ProcessedArguments.Add((null, enumerator.Current));
+            cmd.FileName = enumerator.Current;
 
-        public AnalyzerManager Manager { get; }
-
-        /// <inheritdoc/>
-        public ProjectAnalyzer Analyzer { get; }
-
-        public bool Succeeded { get; internal set; }
-
-        public IReadOnlyDictionary<string, string> Properties => _properties;
-
-        public IReadOnlyDictionary<string, IProjectItem[]> Items => _items;
-
-        /// <inheritdoc/>
-        public Guid ProjectGuid => _projectGuid;
-
-        /// <inheritdoc/>
-        public string Command => _command;
-
-        /// <inheritdoc/>
-        public string CompilerFilePath => _compilerFilePath;
-
-        /// <inheritdoc/>
-        public string[] CompilerArguments => _compilerArguments;
-
-        /// <inheritdoc/>
-        public string GetProperty(string name) =>
-            Properties.TryGetValue(name, out string value) ? value : null;
-
-        public string TargetFramework =>
-            ProjectFile.GetTargetFrameworks(
-                null,  // Don't want all target frameworks since the result is just for one
-                new[] { GetProperty(ProjectFileNames.TargetFramework) },
-                new[] { (GetProperty(ProjectFileNames.TargetFrameworkIdentifier), GetProperty(ProjectFileNames.TargetFrameworkVersion)) })
-            .FirstOrDefault();
-
-        public string[] SourceFiles =>
-            _cscCommandLineArguments
-                ?.Where(x => x.Item1 == null
-                    && !string.Equals(Path.GetFileName(x.Item2), "csc.dll", StringComparison.OrdinalIgnoreCase)
-                    && !string.Equals(Path.GetFileName(x.Item2), "csc.exe", StringComparison.OrdinalIgnoreCase))
-                .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
-                .ToArray() ?? _fscCommandLineArguments
-                ?.Where(x => x.Item1 == null
-                    && x.Item2?.Contains("fsc.dll") == false
-                    && x.Item2?.Contains("fsc.exe") == false)
-                .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
-                .ToArray() ?? _vbcCommandLineArguments
-                ?.Where(x => x.Item1 == null && !_assemblyObjects.Contains(Path.GetFileName(x.Item2), StringComparer.OrdinalIgnoreCase))
-                .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
-                .ToArray() ?? Array.Empty<string>();
-
-        public string[] References =>
-            _cscCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("reference", StringComparison.OrdinalIgnoreCase))
-                .Select(x => x.Item2)
-                .ToArray()
-            ?? _fscCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("r", StringComparison.OrdinalIgnoreCase))
-                .Select(x => x.Item2)
-                .ToArray()
-            ?? _vbcCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("reference", StringComparison.OrdinalIgnoreCase))
-                .Select(x => x.Item2)
-                .ToArray()
-            ?? Array.Empty<string>();
-
-        public string[] AnalyzerReferences =>
-            _cscCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("analyzer", StringComparison.OrdinalIgnoreCase))
-                .Select(x => x.Item2)
-                .ToArray() ?? Array.Empty<string>();
-
-        public string[] PreprocessorSymbols =>
-            _cscCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("define", StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
-                .Select(x => x.Trim())
-                .ToArray()
-            ?? _vbcCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("define", StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
-                .Select(x => x.Trim())
-                .ToArray()
-            ?? Array.Empty<string>();
-
-        public string[] AdditionalFiles =>
-            _cscCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("additionalfile", StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
-                .Select(x => x.Trim())
-                .ToArray()
-            ?? _vbcCommandLineArguments
-                ?.Where(x => x.Item1 is object && x.Item1.Equals("additionalfile", StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Item2.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
-                .Select(x => x.Trim())
-                .ToArray()
-            ?? Array.Empty<string>();
-
-        public IEnumerable<string> ProjectReferences =>
-            Items.TryGetValue("ProjectReference", out IProjectItem[] items)
-                ? items.Distinct(new ProjectItemItemSpecEqualityComparer())
-                       .Select(x => AnalyzerManager.NormalizePath(
-                            Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.ItemSpec)))
-                : Array.Empty<string>();
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences =>
-            Items.TryGetValue("PackageReference", out IProjectItem[] items)
-                ? items.Distinct(new ProjectItemItemSpecEqualityComparer()).ToDictionary(x => x.ItemSpec, x => x.Metadata)
-                : new Dictionary<string, IReadOnlyDictionary<string, string>>();
-
-        internal void ProcessProject(PropertiesAndItems propertiesAndItems)
-        {
-            // Add properties
-            foreach (DictionaryEntry entry in propertiesAndItems.Properties.ToDictionaryEntries())
+            // Iterate the rest of parts
+            while (enumerator.MoveNext())
             {
-                _properties[entry.Key.ToString()] = entry.Value.ToString();
-            }
+                string part = enumerator.Current;
+                cmd.Arguments.Add(part);
 
-            // Add items
-            foreach (IGrouping<string, DictionaryEntry> itemGroup in propertiesAndItems.Items.ToDictionaryEntries().GroupBy(x => x.Key.ToString()))
-            {
-                _items[itemGroup.Key] = itemGroup.Select(x => new ProjectItem((ITaskItem)x.Value)).ToArray();
-            }
-        }
-
-        internal void ProcessCscCommandLine(string commandLine, bool coreCompile)
-        {
-            // Some projects can have multiple Csc calls (see #92) so if this is the one inside CoreCompile use it, otherwise use the first
-            if (string.IsNullOrWhiteSpace(commandLine) || (_cscCommandLineArguments != null && !coreCompile))
-            {
-                return;
-            }
-            ProcessedCommandLine cmd = ProcessCscCommandLine(commandLine);
-            _command = cmd.Command;
-            _compilerFilePath = cmd.FileName;
-            _compilerArguments = cmd.Arguments.ToArray();
-            _cscCommandLineArguments = cmd.ProcessedArguments;
-        }
-
-        internal static ProcessedCommandLine ProcessCscCommandLine(string commandLine)
-        {
-            return ProcessCommandLine(commandLine, "csc.");
-        }
-
-        internal struct ProcessedCommandLine
-        {
-            public string Command;
-            public string FileName;
-            public List<string> Arguments;
-            public List<(string, string)> ProcessedArguments;
-        }
-
-        internal static ProcessedCommandLine ProcessCommandLine(string commandLine, string initialCommandEnd)
-        {
-            ProcessedCommandLine cmd;
-            cmd.Command = commandLine;
-            cmd.FileName = string.Empty;
-            cmd.Arguments = new List<string>();
-            cmd.ProcessedArguments = new List<(string, string)>();
-
-            using (IEnumerator<string> enumerator = EnumerateCommandLineParts(commandLine, initialCommandEnd).GetEnumerator())
-            {
-                if (!enumerator.MoveNext())
+                if (part[0] == '/')
                 {
-                    return cmd;
-                }
-
-                // Initial command (csc)
-                cmd.ProcessedArguments.Add((null, enumerator.Current));
-                cmd.FileName = enumerator.Current;
-
-                // Iterate the rest of parts
-                while (enumerator.MoveNext())
-                {
-                    string part = enumerator.Current;
-                    cmd.Arguments.Add(part);
-
-                    if (part[0] == '/')
+                    int valueStart = part.IndexOf(':');
+                    if (valueStart >= 0 && valueStart < part.Length - 1)
                     {
-                        int valueStart = part.IndexOf(':');
-                        if (valueStart >= 0 && valueStart < part.Length - 1)
-                        {
-                            // Argument with a value
-                            cmd.ProcessedArguments.Add((part.Substring(1, valueStart - 1), part.Substring(valueStart + 1)));
-                        }
-                        else
-                        {
-                            // Switch
-                            cmd.ProcessedArguments.Add((valueStart >= 0 ? part.Substring(1, valueStart - 1) : part.Substring(1), null));
-                        }
+                        // Argument with a value
+                        cmd.ProcessedArguments.Add((part.Substring(1, valueStart - 1), part.Substring(valueStart + 1)));
                     }
                     else
                     {
-                        // Argument, not a switch
-                        cmd.ProcessedArguments.Add((null, part));
+                        // Switch
+                        cmd.ProcessedArguments.Add((valueStart >= 0 ? part.Substring(1, valueStart - 1) : part.Substring(1), null));
                     }
                 }
-            }
-
-            return cmd;
-        }
-
-        internal void ProcessVbcCommandLine(string commandLine)
-        {
-            ProcessedCommandLine cmd = ProcessCommandLine(commandLine, "vbc.");
-
-            // vbc comma delimits the references, enumerate and replace
-            int referencesIdx = cmd.ProcessedArguments.FindIndex(x => x.Item1 == "reference");
-            if (referencesIdx >= 0)
-            {
-                (string, string) references = cmd.ProcessedArguments[referencesIdx];
-                cmd.Arguments.RemoveAt(referencesIdx);
-                cmd.ProcessedArguments.RemoveAt(referencesIdx);
-                foreach (string r in references.Item2.Split(','))
+                else
                 {
-                    cmd.Arguments.Add("/reference:\"" + r + "\"");
-                    cmd.ProcessedArguments.Add((references.Item1, r));
+                    // Argument, not a switch
+                    cmd.ProcessedArguments.Add((null, part));
                 }
             }
-
-            _command = cmd.Command;
-            _compilerFilePath = cmd.FileName;
-            _compilerArguments = cmd.Arguments.ToArray();
-            _vbcCommandLineArguments = cmd.ProcessedArguments;
         }
 
-        public bool HasFscArguments()
+        return cmd;
+    }
+
+    internal void ProcessVbcCommandLine(string commandLine)
+    {
+        ProcessedCommandLine cmd = ProcessCommandLine(commandLine, "vbc.");
+
+        // vbc comma delimits the references, enumerate and replace
+        int referencesIdx = cmd.ProcessedArguments.FindIndex(x => x.Item1 == "reference");
+        if (referencesIdx >= 0)
         {
-            return _fscCommandLineArguments?.Count > 0;
-        }
-
-        private static IEnumerable<string> EnumerateCommandLineParts(string commandLine, string initialCommandEnd)
-        {
-            StringBuilder part = new StringBuilder();
-            bool isInQuote = false;
-            bool initialCommand = true;
-
-            using (StringReader reader = new StringReader(commandLine))
+            (string, string) references = cmd.ProcessedArguments[referencesIdx];
+            cmd.Arguments.RemoveAt(referencesIdx);
+            cmd.ProcessedArguments.RemoveAt(referencesIdx);
+            foreach (string r in references.Item2.Split(','))
             {
-                while (reader.Read() is int c && c >= 0)
-                {
-                    switch (c)
-                    {
-                        case '\\':
-                            int next = reader.Read();
-                            if (next == '"')
-                            {
-                                // Escaped quote
-                                part.Append('"');
-                            }
-                            else
-                            {
-                                // Not an escape
-                                part.Append((char)c);
-
-                                if (next >= 0)
-                                {
-                                    part.Append((char)next);
-                                }
-                            }
-                            break;
-                        case '\t':
-                        case '\n':
-                        case '\v':
-                        case '\f':
-                        case '\r':
-                        case ' ':
-                            if (isInQuote || initialCommand)
-                            {
-                                // Treat as a normal char
-                                part.Append((char)c);
-                            }
-                            else if (part.Length > 0)
-                            {
-                                // End of the part
-                                yield return part.ToString();
-                                part.Clear();
-                            }
-                            break;
-                        case '"':
-                            isInQuote = !isInQuote;
-                            break;
-                        default:
-                            part.Append((char)c);
-                            break;
-                    }
-
-                    if (initialCommand && part.ToString().EndsWith(initialCommandEnd, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        initialCommand = false;
-                    }
-                }
-            }
-
-            if (part.Length > 0)
-            {
-                yield return part.ToString();
+                cmd.Arguments.Add("/reference:\"" + r + "\"");
+                cmd.ProcessedArguments.Add((references.Item1, r));
             }
         }
 
-        internal void ProcessFscCommandLine(string commandLine)
+        _command = cmd.Command;
+        _compilerFilePath = cmd.FileName;
+        _compilerArguments = cmd.Arguments.ToArray();
+        _vbcCommandLineArguments = cmd.ProcessedArguments;
+    }
+
+    public bool HasFscArguments()
+    {
+        return _fscCommandLineArguments?.Count > 0;
+    }
+
+    private static IEnumerable<string> EnumerateCommandLineParts(string commandLine, string initialCommandEnd)
+    {
+        StringBuilder part = new StringBuilder();
+        bool isInQuote = false;
+        bool initialCommand = true;
+
+        using (StringReader reader = new StringReader(commandLine))
         {
-            _command = commandLine;
-
-            List<(string, string)> processedArguments = new List<(string, string)>();
-            List<string> arguments = new List<string>();
-
-            bool initialCommand = true;
-            using (IEnumerator<string> enumerator = EnumerateCommandLinePartsFsc(commandLine, initialCommand).GetEnumerator())
+            while (reader.Read() is int c && c >= 0)
             {
-                // Initial command (fsc)
-                processedArguments.Add((null, enumerator.Current));
-                _compilerFilePath = enumerator.Current;
-                initialCommand = false;
-
-                // Iterate the rest of parts
-                while (enumerator.MoveNext())
+                switch (c)
                 {
-                    string part = enumerator.Current;
-                    arguments.Add(part);
-
-                    if (part[0] == '-')
-                    {
-                        int valueStart = part.IndexOf(':');
-                        if (valueStart >= 0 && valueStart < part.Length - 1)
+                    case '\\':
+                        int next = reader.Read();
+                        if (next == '"')
                         {
-                            // Argument with a value
-                            processedArguments.Add((part.Substring(1, valueStart - 1), part.Substring(valueStart + 1)));
+                            // Escaped quote
+                            part.Append('"');
                         }
                         else
                         {
-                            // Switch
-                            processedArguments.Add((valueStart >= 0 ? part.Substring(1, valueStart - 1) : part.Substring(1), null));
+                            // Not an escape
+                            part.Append((char)c);
+
+                            if (next >= 0)
+                            {
+                                part.Append((char)next);
+                            }
                         }
+                        break;
+                    case '\t':
+                    case '\n':
+                    case '\v':
+                    case '\f':
+                    case '\r':
+                    case ' ':
+                        if (isInQuote || initialCommand)
+                        {
+                            // Treat as a normal char
+                            part.Append((char)c);
+                        }
+                        else if (part.Length > 0)
+                        {
+                            // End of the part
+                            yield return part.ToString();
+                            part.Clear();
+                        }
+                        break;
+                    case '"':
+                        isInQuote = !isInQuote;
+                        break;
+                    default:
+                        part.Append((char)c);
+                        break;
+                }
+
+                if (initialCommand && part.ToString().EndsWith(initialCommandEnd, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    initialCommand = false;
+                }
+            }
+        }
+
+        if (part.Length > 0)
+        {
+            yield return part.ToString();
+        }
+    }
+
+    internal void ProcessFscCommandLine(string commandLine)
+    {
+        _command = commandLine;
+
+        List<(string, string)> processedArguments = new List<(string, string)>();
+        List<string> arguments = new List<string>();
+
+        bool initialCommand = true;
+        using (IEnumerator<string> enumerator = EnumerateCommandLinePartsFsc(commandLine, initialCommand).GetEnumerator())
+        {
+            // Initial command (fsc)
+            processedArguments.Add((null, enumerator.Current));
+            _compilerFilePath = enumerator.Current;
+            initialCommand = false;
+
+            // Iterate the rest of parts
+            while (enumerator.MoveNext())
+            {
+                string part = enumerator.Current;
+                arguments.Add(part);
+
+                if (part[0] == '-')
+                {
+                    int valueStart = part.IndexOf(':');
+                    if (valueStart >= 0 && valueStart < part.Length - 1)
+                    {
+                        // Argument with a value
+                        processedArguments.Add((part.Substring(1, valueStart - 1), part.Substring(valueStart + 1)));
                     }
                     else
                     {
-                        // Argument, not a switch
-                        processedArguments.Add((null, part));
+                        // Switch
+                        processedArguments.Add((valueStart >= 0 ? part.Substring(1, valueStart - 1) : part.Substring(1), null));
                     }
                 }
-            }
-
-            _fscCommandLineArguments = processedArguments;
-            _compilerArguments = arguments.ToArray();
-        }
-
-        private static IEnumerable<string> EnumerateCommandLinePartsFsc(string commandLine, bool initialCommand)
-        {
-            StringBuilder part = new StringBuilder();
-            bool isInQuote = false;
-
-            using (StringReader reader = new StringReader(commandLine))
-            {
-                while (reader.Read() is int c && c >= 0)
+                else
                 {
-                    switch (c)
-                    {
-                        case '\\':
-                            int next = reader.Read();
-                            if (next == '"')
-                            {
-                                // Escaped quote
-                                part.Append('"');
-                            }
-                            else
-                            {
-                                // Not an escape
-                                part.Append((char)c);
-
-                                if (next >= 0)
-                                {
-                                    part.Append((char)next);
-                                }
-                            }
-                            break;
-                        case '\t':
-                        case '\n':
-                        case '\v':
-                        case '\f':
-                        case '\r':
-                            if (isInQuote || initialCommand)
-                            {
-                                // Treat as a normal char
-                                part.Append((char)c);
-                            }
-                            else if (reader.Read() == '\n')
-                            {
-                                // End of the part
-                                yield return part.ToString();
-                                part.Clear();
-                            }
-                            break;
-
-                        // case ' ':
-                        case '"':
-                            isInQuote = !isInQuote;
-                            break;
-                        default:
-                            part.Append((char)c);
-                            break;
-                    }
-
-                    if (initialCommand && part.ToString().EndsWith("fsc.", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        initialCommand = false;
-                    }
+                    // Argument, not a switch
+                    processedArguments.Add((null, part));
                 }
             }
+        }
 
-            if (part.Length > 0)
+        _fscCommandLineArguments = processedArguments;
+        _compilerArguments = arguments.ToArray();
+    }
+
+    private static IEnumerable<string> EnumerateCommandLinePartsFsc(string commandLine, bool initialCommand)
+    {
+        StringBuilder part = new StringBuilder();
+        bool isInQuote = false;
+
+        using (StringReader reader = new StringReader(commandLine))
+        {
+            while (reader.Read() is int c && c >= 0)
             {
-                yield return part.ToString();
+                switch (c)
+                {
+                    case '\\':
+                        int next = reader.Read();
+                        if (next == '"')
+                        {
+                            // Escaped quote
+                            part.Append('"');
+                        }
+                        else
+                        {
+                            // Not an escape
+                            part.Append((char)c);
+
+                            if (next >= 0)
+                            {
+                                part.Append((char)next);
+                            }
+                        }
+                        break;
+                    case '\t':
+                    case '\n':
+                    case '\v':
+                    case '\f':
+                    case '\r':
+                        if (isInQuote || initialCommand)
+                        {
+                            // Treat as a normal char
+                            part.Append((char)c);
+                        }
+                        else if (reader.Read() == '\n')
+                        {
+                            // End of the part
+                            yield return part.ToString();
+                            part.Clear();
+                        }
+                        break;
+
+                    // case ' ':
+                    case '"':
+                        isInQuote = !isInQuote;
+                        break;
+                    default:
+                        part.Append((char)c);
+                        break;
+                }
+
+                if (initialCommand && part.ToString().EndsWith("fsc.", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    initialCommand = false;
+                }
             }
         }
 
-        private class ProjectItemItemSpecEqualityComparer : IEqualityComparer<IProjectItem>
+        if (part.Length > 0)
         {
-            public bool Equals(IProjectItem x, IProjectItem y) => x.ItemSpec.Equals(y.ItemSpec, StringComparison.OrdinalIgnoreCase);
-
-            public int GetHashCode(IProjectItem obj) => obj.ItemSpec.ToLowerInvariant().GetHashCode();
+            yield return part.ToString();
         }
+    }
+
+    private class ProjectItemItemSpecEqualityComparer : IEqualityComparer<IProjectItem>
+    {
+        public bool Equals(IProjectItem x, IProjectItem y) => x.ItemSpec.Equals(y.ItemSpec, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(IProjectItem obj) => obj.ItemSpec.ToLowerInvariant().GetHashCode();
     }
 }

--- a/src/Buildalyzer/AnalyzerResults.cs
+++ b/src/Buildalyzer/AnalyzerResults.cs
@@ -4,55 +4,54 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class AnalyzerResults : IAnalyzerResults
 {
-    public class AnalyzerResults : IAnalyzerResults
+    private readonly ConcurrentDictionary<string, IAnalyzerResult> _results = new ConcurrentDictionary<string, IAnalyzerResult>();
+
+    private bool? _overallSuccess = null;
+
+    public bool OverallSuccess => _overallSuccess == true;
+
+    internal void Add(IEnumerable<IAnalyzerResult> results, bool overallSuccess)
     {
-        private readonly ConcurrentDictionary<string, IAnalyzerResult> _results = new ConcurrentDictionary<string, IAnalyzerResult>();
-
-        private bool? _overallSuccess = null;
-
-        public bool OverallSuccess => _overallSuccess == true;
-
-        internal void Add(IEnumerable<IAnalyzerResult> results, bool overallSuccess)
+        foreach (IAnalyzerResult result in results)
         {
-            foreach (IAnalyzerResult result in results)
-            {
-                _results[result.TargetFramework ?? string.Empty] = result;
-            }
-            _overallSuccess = _overallSuccess.HasValue ? _overallSuccess.Value && overallSuccess : overallSuccess;
+            _results[result.TargetFramework ?? string.Empty] = result;
         }
+        _overallSuccess = _overallSuccess.HasValue ? _overallSuccess.Value && overallSuccess : overallSuccess;
+    }
 
-        public IAnalyzerResult this[string targetFramework] => _results[targetFramework];
+    public IAnalyzerResult this[string targetFramework] => _results[targetFramework];
 
-        public IEnumerable<string> TargetFrameworks => _results.Keys.OrderBy(e => e, TargetFrameworkComparer.Instance);
+    public IEnumerable<string> TargetFrameworks => _results.Keys.OrderBy(e => e, TargetFrameworkComparer.Instance);
 
-        public IEnumerable<IAnalyzerResult> Results => TargetFrameworks.Select(e => _results[e]);
+    public IEnumerable<IAnalyzerResult> Results => TargetFrameworks.Select(e => _results[e]);
 
-        public int Count => _results.Count;
+    public int Count => _results.Count;
 
-        public bool ContainsTargetFramework(string targetFramework) => _results.ContainsKey(targetFramework);
+    public bool ContainsTargetFramework(string targetFramework) => _results.ContainsKey(targetFramework);
 
-        public bool TryGetTargetFramework(string targetFramework, out IAnalyzerResult result) => _results.TryGetValue(targetFramework, out result);
+    public bool TryGetTargetFramework(string targetFramework, out IAnalyzerResult result) => _results.TryGetValue(targetFramework, out result);
 
-        public IEnumerator<IAnalyzerResult> GetEnumerator() => Results.GetEnumerator();
+    public IEnumerator<IAnalyzerResult> GetEnumerator() => Results.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        private class TargetFrameworkComparer : IComparer<string>
+    private class TargetFrameworkComparer : IComparer<string>
+    {
+        public static TargetFrameworkComparer Instance { get; } = new TargetFrameworkComparer();
+
+        public int Compare(string x, string y)
         {
-            public static TargetFrameworkComparer Instance { get; } = new TargetFrameworkComparer();
-
-            public int Compare(string x, string y)
+            return (string.IsNullOrEmpty(x), string.IsNullOrEmpty(y)) switch
             {
-                return (string.IsNullOrEmpty(x), string.IsNullOrEmpty(y)) switch
-                {
-                    (true, true) => 0,
-                    (true, false) => +1,
-                    (false, true) => -1,
-                    _ => StringComparer.OrdinalIgnoreCase.Compare(x, y)
-                };
-            }
+                (true, true) => 0,
+                (true, false) => +1,
+                (false, true) => -1,
+                _ => StringComparer.OrdinalIgnoreCase.Compare(x, y)
+            };
         }
     }
 }

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <Description>A little utility to perform design-time builds of .NET projects without having to think too hard about it. Should work with any project type on any .NET runtime.</Description>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
@@ -10,6 +13,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.1" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.815" Aliases="StructuredLogger" />
   </ItemGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Buildalyzer.Tests</_Parameter1>
@@ -18,7 +22,9 @@
       <_Parameter1>Buildalyzer.Workspaces</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Buildalyzer.Logger\Buildalyzer.Logger.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/Buildalyzer/Construction/IPackageReference.cs
+++ b/src/Buildalyzer/Construction/IPackageReference.cs
@@ -1,8 +1,7 @@
-﻿namespace Buildalyzer.Construction
+﻿namespace Buildalyzer.Construction;
+
+public interface IPackageReference
 {
-    public interface IPackageReference
-    {
-        string Name { get; }
-        string Version { get; }
-    }
+    string Name { get; }
+    string Version { get; }
 }

--- a/src/Buildalyzer/Construction/IProjectFile.cs
+++ b/src/Buildalyzer/Construction/IProjectFile.cs
@@ -1,80 +1,79 @@
 ﻿using System.Collections.Generic;
 
-namespace Buildalyzer.Construction
+namespace Buildalyzer.Construction;
+
+public interface IProjectFile
 {
-    public interface IProjectFile
-    {
-        /// <summary>
-        /// Whether the project file contains <c>PackageReference</c> items.
-        /// </summary>
-        bool ContainsPackageReferences { get; }
+    /// <summary>
+    /// Whether the project file contains <c>PackageReference</c> items.
+    /// </summary>
+    bool ContainsPackageReferences { get; }
 
-        /// <summary>
-        /// Whether the project file is multi-targeted.
-        /// </summary>
-        /// <remarks>
-        /// Checks for an <c>TargetFrameworks</c> element.
-        /// </remarks>
-        bool IsMultiTargeted { get; }
+    /// <summary>
+    /// Whether the project file is multi-targeted.
+    /// </summary>
+    /// <remarks>
+    /// Checks for an <c>TargetFrameworks</c> element.
+    /// </remarks>
+    bool IsMultiTargeted { get; }
 
-        /// <summary>
-        /// The list of <c>PackageReference</c> items in the project file.
-        /// </summary>
-        IReadOnlyList<IPackageReference> PackageReferences { get; }
+    /// <summary>
+    /// The list of <c>PackageReference</c> items in the project file.
+    /// </summary>
+    IReadOnlyList<IPackageReference> PackageReferences { get; }
 
-        /// <summary>
-        /// The full path to the project file.
-        /// </summary>
-        string Path { get; }
+    /// <summary>
+    /// The full path to the project file.
+    /// </summary>
+    string Path { get; }
 
-        /// <summary>
-        /// Project name.
-        /// </summary>
-        string Name { get; }
+    /// <summary>
+    /// Project name.
+    /// </summary>
+    string Name { get; }
 
-        /// <summary>
-        /// Whether the project file requires a .NET Framework host and build tools to build.
-        /// </summary>
-        /// <remarks>
-        /// Checks for an <c>Import</c> element with a <c>Project</c> attribute ending with one of the targets in <see cref="ProjectFile.ImportsThatRequireNetFramework"/>.
-        /// Also looks for a <c>LanguageTargets</c> ending with one of the targets in <see cref="ProjectFile.ImportsThatRequireNetFramework"/>.
-        /// Projects that use these targets are known not to build under a .NET Core host or build tools.
-        /// Also checks for a <c>ToolsVersion</c> attribute and uses the .NET Framework if one is found.
-        /// </remarks>
-        bool RequiresNetFramework { get; }
+    /// <summary>
+    /// Whether the project file requires a .NET Framework host and build tools to build.
+    /// </summary>
+    /// <remarks>
+    /// Checks for an <c>Import</c> element with a <c>Project</c> attribute ending with one of the targets in <see cref="ProjectFile.ImportsThatRequireNetFramework"/>.
+    /// Also looks for a <c>LanguageTargets</c> ending with one of the targets in <see cref="ProjectFile.ImportsThatRequireNetFramework"/>.
+    /// Projects that use these targets are known not to build under a .NET Core host or build tools.
+    /// Also checks for a <c>ToolsVersion</c> attribute and uses the .NET Framework if one is found.
+    /// </remarks>
+    bool RequiresNetFramework { get; }
 
-        /// <summary>
-        /// The target framework(s) in the project file.
-        /// </summary>
-        /// <remarks>
-        /// This does not perform evaluation of the project file, only parsing.
-        /// If TargetFramework or TargetFrameworks contains a property that
-        /// needs to be evaluated, this will contain the pre-evaluated value(s).
-        /// Try to find a TargetFrameworkIdentifier in the same PropertyGroup
-        /// and if no TargetFrameworkIdentifier was found, assume ".NETFramework".
-        /// </remarks>
-        string[] TargetFrameworks { get; }
+    /// <summary>
+    /// The target framework(s) in the project file.
+    /// </summary>
+    /// <remarks>
+    /// This does not perform evaluation of the project file, only parsing.
+    /// If TargetFramework or TargetFrameworks contains a property that
+    /// needs to be evaluated, this will contain the pre-evaluated value(s).
+    /// Try to find a TargetFrameworkIdentifier in the same PropertyGroup
+    /// and if no TargetFrameworkIdentifier was found, assume ".NETFramework".
+    /// </remarks>
+    string[] TargetFrameworks { get; }
 
-        /// <summary>
-        /// Gets the <c>ToolsVersion</c> attribute of the <c>Project</c> element (or <c>null</c> if there isn't one).
-        /// </summary>
-        string ToolsVersion { get; }
+    /// <summary>
+    /// Gets the <c>ToolsVersion</c> attribute of the <c>Project</c> element (or <c>null</c> if there isn't one).
+    /// </summary>
+    string ToolsVersion { get; }
 
-        /// <summary>
-        /// Whether the project file uses an SDK.
-        /// </summary>
-        /// <remarks>
-        /// Checks for an <c>Sdk</c> attribute on the <c>Project</c> element. If one can't be found,
-        /// also checks for <c>Import</c> elements with an <c>Sdk</c> attribute (see https://github.com/Microsoft/msbuild/issues/1493).
-        /// </remarks>
-        bool UsesSdk { get; }
+    /// <summary>
+    /// Whether the project file uses an SDK.
+    /// </summary>
+    /// <remarks>
+    /// Checks for an <c>Sdk</c> attribute on the <c>Project</c> element. If one can't be found,
+    /// also checks for <c>Import</c> elements with an <c>Sdk</c> attribute (see https://github.com/Microsoft/msbuild/issues/1493).
+    /// </remarks>
+    bool UsesSdk { get; }
 
-        /// <summary>
-        /// The output type of the project.
-        /// </summary>
-        /// <remarks>
-        /// Checks for an <c>OutputType</c> element.
-        /// </remarks>
-        string OutputType { get; }
-    }
+    /// <summary>
+    /// The output type of the project.
+    /// </summary>
+    /// <remarks>
+    /// Checks for an <c>OutputType</c> element.
+    /// </remarks>
+    string OutputType { get; }
 }

--- a/src/Buildalyzer/Construction/PackageReference.cs
+++ b/src/Buildalyzer/Construction/PackageReference.cs
@@ -1,17 +1,15 @@
-﻿using System;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 
-namespace Buildalyzer.Construction
+namespace Buildalyzer.Construction;
+
+public class PackageReference : IPackageReference
 {
-    public class PackageReference : IPackageReference
-    {
-        public string Name { get; }
-        public string Version { get; }
+    public string Name { get; }
+    public string Version { get; }
 
-        internal PackageReference(XElement packageReferenceElement)
-        {
-            this.Name = packageReferenceElement.GetAttributeValue("Include") ?? packageReferenceElement.GetAttributeValue("Update");
-            this.Version = packageReferenceElement.GetAttributeValue("Version");
-        }
+    internal PackageReference(XElement packageReferenceElement)
+    {
+        this.Name = packageReferenceElement.GetAttributeValue("Include") ?? packageReferenceElement.GetAttributeValue("Update");
+        this.Version = packageReferenceElement.GetAttributeValue("Version");
     }
 }

--- a/src/Buildalyzer/Construction/ProjectFile.cs
+++ b/src/Buildalyzer/Construction/ProjectFile.cs
@@ -4,152 +4,151 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
-namespace Buildalyzer.Construction
+namespace Buildalyzer.Construction;
+
+/// <summary>
+/// Encapsulates an MSBuild project file and provides some information about it's format.
+/// This class only parses the existing XML and does not perform any evaluation.
+/// </summary>
+public class ProjectFile : IProjectFile
 {
     /// <summary>
-    /// Encapsulates an MSBuild project file and provides some information about it's format.
-    /// This class only parses the existing XML and does not perform any evaluation.
+    /// These imports are known to require a .NET Framework host and build tools.
     /// </summary>
-    public class ProjectFile : IProjectFile
+    public static readonly string[] ImportsThatRequireNetFramework = new string[]
     {
-        /// <summary>
-        /// These imports are known to require a .NET Framework host and build tools.
-        /// </summary>
-        public static readonly string[] ImportsThatRequireNetFramework = new string[]
+        "Microsoft.Portable.CSharp.targets",
+        "Microsoft.Windows.UI.Xaml.CSharp.targets"
+    };
+
+    private readonly XDocument _document;
+    private readonly XElement _projectElement;
+
+    private string[] _targetFrameworks = null;
+
+    // The project file path should already be normalized
+    internal ProjectFile(string path)
+    {
+        Path = path;
+        Name = new FileInfo(path).Name;
+        _document = XDocument.Load(path);
+
+        // Get the project element
+        _projectElement = _document.GetDescendants(ProjectFileNames.Project).FirstOrDefault();
+        if (_projectElement == null)
         {
-            "Microsoft.Portable.CSharp.targets",
-            "Microsoft.Windows.UI.Xaml.CSharp.targets"
-        };
-
-        private readonly XDocument _document;
-        private readonly XElement _projectElement;
-
-        private string[] _targetFrameworks = null;
-
-        // The project file path should already be normalized
-        internal ProjectFile(string path)
-        {
-            Path = path;
-            Name = new FileInfo(path).Name;
-            _document = XDocument.Load(path);
-
-            // Get the project element
-            _projectElement = _document.GetDescendants(ProjectFileNames.Project).FirstOrDefault();
-            if (_projectElement == null)
-            {
-                throw new ArgumentException("Unrecognized project file format");
-            }
+            throw new ArgumentException("Unrecognized project file format");
         }
-
-        /// <inheritdoc />
-        public string Path { get; }
-
-        /// <inheritdoc />
-        public string Name { get; }
-
-        /// <inheritdoc />
-        public string[] TargetFrameworks => _targetFrameworks
-            ?? (_targetFrameworks = GetTargetFrameworks(
-                _projectElement.GetDescendants(ProjectFileNames.TargetFrameworks).Select(x => x.Value),
-                _projectElement.GetDescendants(ProjectFileNames.TargetFramework).Select(x => x.Value),
-                _projectElement.GetDescendants(ProjectFileNames.TargetFrameworkVersion)
-                    .Select(x => (x.Parent.GetDescendants(ProjectFileNames.TargetFrameworkIdentifier).FirstOrDefault()?.Value ?? ".NETFramework", x.Value))));
-
-        /// <inheritdoc />
-        public bool UsesSdk =>
-            _projectElement.GetAttributeValue(ProjectFileNames.Sdk) != null
-                || _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => x.GetAttributeValue(ProjectFileNames.Sdk) != null);
-
-        /// <inheritdoc />
-        public bool RequiresNetFramework =>
-            _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => ImportsThatRequireNetFramework.Any(i => x.GetAttributeValue(ProjectFileNames.Project)?.EndsWith(i, StringComparison.OrdinalIgnoreCase) ?? false))
-            || _projectElement.GetDescendants(ProjectFileNames.LanguageTargets).Any(x => ImportsThatRequireNetFramework.Any(i => x.Value.EndsWith(i, StringComparison.OrdinalIgnoreCase)))
-            || ToolsVersion != null;
-
-        /// <inheritdoc />
-        public bool IsMultiTargeted => _projectElement.GetDescendants(ProjectFileNames.TargetFrameworks).Any();
-
-        /// <inheritdoc />
-        public string OutputType => _projectElement.GetDescendants(ProjectFileNames.OutputType).FirstOrDefault()?.Value;
-
-        /// <inheritdoc />
-        public bool ContainsPackageReferences => _projectElement.GetDescendants(ProjectFileNames.PackageReference).Any();
-
-        /// <inheritdoc />
-        public IReadOnlyList<IPackageReference> PackageReferences => _projectElement.GetDescendants(ProjectFileNames.PackageReference).Select(s => new PackageReference(s)).ToList();
-
-        /// <inheritdoc />
-        public string ToolsVersion => _projectElement.GetAttributeValue(ProjectFileNames.ToolsVersion);
-
-        internal static string[] GetTargetFrameworks(
-            IEnumerable<string> targetFrameworksValues,
-            IEnumerable<string> targetFrameworkValues,
-            IEnumerable<(string, string)> targetFrameworkIdentifierAndVersionValues)
-        {
-            // Use TargetFrameworks and/or TargetFramework if either were found
-            IEnumerable<string> allTargetFrameworks = null;
-            if (targetFrameworksValues != null)
-            {
-                allTargetFrameworks = targetFrameworksValues
-                    .Where(x => x != null)
-                    .SelectMany(x => x.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(v => v.Trim()));
-            }
-            if (targetFrameworkValues != null)
-            {
-                allTargetFrameworks = allTargetFrameworks == null
-                    ? targetFrameworkValues.Where(x => x != null).Select(x => x.Trim())
-                    : allTargetFrameworks.Concat(targetFrameworkValues.Where(x => x != null).Select(x => x.Trim()));
-            }
-            if (allTargetFrameworks != null)
-            {
-                string[] distinctTargetFrameworks = allTargetFrameworks.Distinct().ToArray();
-                if (distinctTargetFrameworks.Length > 0)
-                {
-                    // Only return if we actually found any
-                    return distinctTargetFrameworks;
-                }
-            }
-
-            // Otherwise, try to find a TargetFrameworkIdentifier and/or TargetFrameworkVersion and puzzle it out
-            // This is really hacky, would be great to find an official mapping
-            // This is also unreliable because a particular TargetFrameworkIdentifier could result from different TargetFramework
-            // For example, both "win" and "uap" TargetFramework map back to ".NETCore" TargetFrameworkIdentifier
-            return targetFrameworkIdentifierAndVersionValues?
-                .Where(value => value.Item1 != null && value.Item2 != null)
-                .Select(value =>
-                {
-                    // If we have a mapping, use it
-                    if (TargetFrameworkIdentifierToTargetFramework.TryGetValue(value.Item1, out (string, bool) targetFramework))
-                    {
-                        // Append the TargetFrameworkVersion, stripping non-digits (this probably isn't correct in some cases)
-                        return targetFramework.Item1 + new string(value.Item2.Where(x => char.IsDigit(x) || (targetFramework.Item2 && x == '.')).ToArray());
-                    }
-
-                    // Otherwise ¯\_(ツ)_/¯
-                    return null;
-                })
-                .Where(x => x != null).ToArray()
-                    ?? Array.Empty<string>();
-        }
-
-        // Map from TargetFrameworkIdentifier back to a TargetFramework
-        // Partly from https://github.com/onovotny/sdk/blob/83d93a58c0955386218d536580eac2ab1582b397/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
-        // See also https://blog.stephencleary.com/2012/05/framework-profiles-in-net.html
-        // Can't handle ".NETPortable" because those split out as complex "portable-" TargetFramework
-        // Value = (TargetFramework, preserve dots in version)
-        private static readonly Dictionary<string, (string, bool)> TargetFrameworkIdentifierToTargetFramework = new Dictionary<string, (string, bool)>
-        {
-            { ".NETStandard", ("netstandard", true) },
-            { ".NETCoreApp", ("netcoreapp", true) },
-            { ".NETFramework", ("net", false) },
-            { ".NETCore", ("uap", true) },
-            { "WindowsPhoneApp", ("wpa", false) },
-            { "WindowsPhone", ("wp", false) },
-            { "Xamarin.iOS", ("xamarinios", false) },
-            { "MonoAndroid", ("monoandroid", false) },
-            { "Xamarin.TVOS", ("xamarintvos", false) },
-            { "Xamarin.WatchOS", ("xamarinwatchos", false) },
-            { "Xamarin.Mac", ("xamarinmac", false) }
-        };
     }
+
+    /// <inheritdoc />
+    public string Path { get; }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public string[] TargetFrameworks => _targetFrameworks
+        ?? (_targetFrameworks = GetTargetFrameworks(
+            _projectElement.GetDescendants(ProjectFileNames.TargetFrameworks).Select(x => x.Value),
+            _projectElement.GetDescendants(ProjectFileNames.TargetFramework).Select(x => x.Value),
+            _projectElement.GetDescendants(ProjectFileNames.TargetFrameworkVersion)
+                .Select(x => (x.Parent.GetDescendants(ProjectFileNames.TargetFrameworkIdentifier).FirstOrDefault()?.Value ?? ".NETFramework", x.Value))));
+
+    /// <inheritdoc />
+    public bool UsesSdk =>
+        _projectElement.GetAttributeValue(ProjectFileNames.Sdk) != null
+            || _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => x.GetAttributeValue(ProjectFileNames.Sdk) != null);
+
+    /// <inheritdoc />
+    public bool RequiresNetFramework =>
+        _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => ImportsThatRequireNetFramework.Any(i => x.GetAttributeValue(ProjectFileNames.Project)?.EndsWith(i, StringComparison.OrdinalIgnoreCase) ?? false))
+        || _projectElement.GetDescendants(ProjectFileNames.LanguageTargets).Any(x => ImportsThatRequireNetFramework.Any(i => x.Value.EndsWith(i, StringComparison.OrdinalIgnoreCase)))
+        || ToolsVersion != null;
+
+    /// <inheritdoc />
+    public bool IsMultiTargeted => _projectElement.GetDescendants(ProjectFileNames.TargetFrameworks).Any();
+
+    /// <inheritdoc />
+    public string OutputType => _projectElement.GetDescendants(ProjectFileNames.OutputType).FirstOrDefault()?.Value;
+
+    /// <inheritdoc />
+    public bool ContainsPackageReferences => _projectElement.GetDescendants(ProjectFileNames.PackageReference).Any();
+
+    /// <inheritdoc />
+    public IReadOnlyList<IPackageReference> PackageReferences => _projectElement.GetDescendants(ProjectFileNames.PackageReference).Select(s => new PackageReference(s)).ToList();
+
+    /// <inheritdoc />
+    public string ToolsVersion => _projectElement.GetAttributeValue(ProjectFileNames.ToolsVersion);
+
+    internal static string[] GetTargetFrameworks(
+        IEnumerable<string> targetFrameworksValues,
+        IEnumerable<string> targetFrameworkValues,
+        IEnumerable<(string, string)> targetFrameworkIdentifierAndVersionValues)
+    {
+        // Use TargetFrameworks and/or TargetFramework if either were found
+        IEnumerable<string> allTargetFrameworks = null;
+        if (targetFrameworksValues != null)
+        {
+            allTargetFrameworks = targetFrameworksValues
+                .Where(x => x != null)
+                .SelectMany(x => x.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(v => v.Trim()));
+        }
+        if (targetFrameworkValues != null)
+        {
+            allTargetFrameworks = allTargetFrameworks == null
+                ? targetFrameworkValues.Where(x => x != null).Select(x => x.Trim())
+                : allTargetFrameworks.Concat(targetFrameworkValues.Where(x => x != null).Select(x => x.Trim()));
+        }
+        if (allTargetFrameworks != null)
+        {
+            string[] distinctTargetFrameworks = allTargetFrameworks.Distinct().ToArray();
+            if (distinctTargetFrameworks.Length > 0)
+            {
+                // Only return if we actually found any
+                return distinctTargetFrameworks;
+            }
+        }
+
+        // Otherwise, try to find a TargetFrameworkIdentifier and/or TargetFrameworkVersion and puzzle it out
+        // This is really hacky, would be great to find an official mapping
+        // This is also unreliable because a particular TargetFrameworkIdentifier could result from different TargetFramework
+        // For example, both "win" and "uap" TargetFramework map back to ".NETCore" TargetFrameworkIdentifier
+        return targetFrameworkIdentifierAndVersionValues?
+            .Where(value => value.Item1 != null && value.Item2 != null)
+            .Select(value =>
+            {
+                // If we have a mapping, use it
+                if (TargetFrameworkIdentifierToTargetFramework.TryGetValue(value.Item1, out (string, bool) targetFramework))
+                {
+                    // Append the TargetFrameworkVersion, stripping non-digits (this probably isn't correct in some cases)
+                    return targetFramework.Item1 + new string(value.Item2.Where(x => char.IsDigit(x) || (targetFramework.Item2 && x == '.')).ToArray());
+                }
+
+                // Otherwise ¯\_(ツ)_/¯
+                return null;
+            })
+            .Where(x => x != null).ToArray()
+                ?? Array.Empty<string>();
+    }
+
+    // Map from TargetFrameworkIdentifier back to a TargetFramework
+    // Partly from https://github.com/onovotny/sdk/blob/83d93a58c0955386218d536580eac2ab1582b397/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+    // See also https://blog.stephencleary.com/2012/05/framework-profiles-in-net.html
+    // Can't handle ".NETPortable" because those split out as complex "portable-" TargetFramework
+    // Value = (TargetFramework, preserve dots in version)
+    private static readonly Dictionary<string, (string, bool)> TargetFrameworkIdentifierToTargetFramework = new Dictionary<string, (string, bool)>
+    {
+        { ".NETStandard", ("netstandard", true) },
+        { ".NETCoreApp", ("netcoreapp", true) },
+        { ".NETFramework", ("net", false) },
+        { ".NETCore", ("uap", true) },
+        { "WindowsPhoneApp", ("wpa", false) },
+        { "WindowsPhone", ("wp", false) },
+        { "Xamarin.iOS", ("xamarinios", false) },
+        { "MonoAndroid", ("monoandroid", false) },
+        { "Xamarin.TVOS", ("xamarintvos", false) },
+        { "Xamarin.WatchOS", ("xamarinwatchos", false) },
+        { "Xamarin.Mac", ("xamarinmac", false) }
+    };
 }

--- a/src/Buildalyzer/Construction/ProjectFileNames.cs
+++ b/src/Buildalyzer/Construction/ProjectFileNames.cs
@@ -1,20 +1,19 @@
-﻿namespace Buildalyzer.Construction
-{
-    public static class ProjectFileNames
-    {
-        // Elements
-        public const string Project = nameof(Project);
-        public const string TargetFramework = nameof(TargetFramework);
-        public const string TargetFrameworks = nameof(TargetFrameworks);
-        public const string TargetFrameworkIdentifier = nameof(TargetFrameworkIdentifier);
-        public const string TargetFrameworkVersion = nameof(TargetFrameworkVersion);
-        public const string Import = nameof(Import);
-        public const string PackageReference = nameof(PackageReference);
-        public const string ToolsVersion = nameof(ToolsVersion);
-        public const string LanguageTargets = nameof(LanguageTargets);
-        public const string OutputType = nameof(OutputType);
+﻿namespace Buildalyzer.Construction;
 
-        // Attributes
-        public const string Sdk = nameof(Sdk);
-    }
+public static class ProjectFileNames
+{
+    // Elements
+    public const string Project = nameof(Project);
+    public const string TargetFramework = nameof(TargetFramework);
+    public const string TargetFrameworks = nameof(TargetFrameworks);
+    public const string TargetFrameworkIdentifier = nameof(TargetFrameworkIdentifier);
+    public const string TargetFrameworkVersion = nameof(TargetFrameworkVersion);
+    public const string Import = nameof(Import);
+    public const string PackageReference = nameof(PackageReference);
+    public const string ToolsVersion = nameof(ToolsVersion);
+    public const string LanguageTargets = nameof(LanguageTargets);
+    public const string OutputType = nameof(OutputType);
+
+    // Attributes
+    public const string Sdk = nameof(Sdk);
 }

--- a/src/Buildalyzer/EmptyDisposable.cs
+++ b/src/Buildalyzer/EmptyDisposable.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class EmptyDisposable : IDisposable
 {
-    public class EmptyDisposable : IDisposable
+    public void Dispose()
     {
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -1,169 +1,166 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Environment
+namespace Buildalyzer.Environment;
+
+/// <summary>
+/// An immutable representation of a particular build environment (paths, properties, etc).
+/// </summary>
+public sealed class BuildEnvironment
 {
+    // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription
+    // .NET "Core" will return ".NET Core" up to 3.x and ".NET" for > 5
+    public static bool IsRunningOnCore =>
+        !System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
+            .Replace(" ", string.Empty)
+            .Trim()
+            .StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase);
+
+    private readonly Dictionary<string, string> _globalProperties;
+    private readonly Dictionary<string, string> _environmentVariables;
+
+    // Used for cloning
+    private readonly IDictionary<string, string> _additionalGlobalProperties;
+    private readonly IDictionary<string, string> _additionalEnvironmentVariables;
+
     /// <summary>
-    /// An immutable representation of a particular build environment (paths, properties, etc).
+    /// Indicates that a design-time build should be performed.
     /// </summary>
-    public sealed class BuildEnvironment
+    /// <remarks>
+    /// See https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md.
+    /// </remarks>
+    public bool DesignTime { get; }
+
+    /// <summary>
+    /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
+    /// </summary>
+    public bool Restore { get; }
+
+    public string[] TargetsToBuild { get; }
+
+    public string MsBuildExePath { get; }
+
+    public string DotnetExePath { get; }
+
+    public string WorkingDirectory { get; }
+
+    /// <summary>
+    /// Indicates if the <c>-noAutoResponse</c> argument should be set (the default is <c>true</c>).
+    /// This is required if a <c>.rsp</c> file might conflict with the command-line arguments and binary
+    /// logger that Buildalyzer uses. Setting this to false will omit the <c>-noAutoResponse</c> argument
+    /// but might also result in failed builds or incomplete information being sent to Buildalyzer.
+    /// See https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files.
+    /// </summary>
+    public bool NoAutoResponse { get; set; } = true;
+
+    public IEnumerable<string> Arguments { get; }
+
+    public IReadOnlyDictionary<string, string> GlobalProperties => _globalProperties;
+
+    public IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
+
+    public BuildEnvironment(
+        bool designTime,
+        bool restore,
+        string[] targetsToBuild,
+        string msBuildExePath,
+        string dotnetExePath,
+        IEnumerable<string> arguments,
+        IDictionary<string, string> additionalGlobalProperties = null,
+        IDictionary<string, string> additionalEnvironmentVariables = null,
+        string workingDirectory = null)
     {
-        // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription
-        // .NET "Core" will return ".NET Core" up to 3.x and ".NET" for > 5
-        public static bool IsRunningOnCore =>
-            !System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
-                .Replace(" ", string.Empty)
-                .Trim()
-                .StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase);
+        DesignTime = designTime;
+        Restore = restore;
+        TargetsToBuild = targetsToBuild ?? throw new ArgumentNullException(nameof(targetsToBuild));
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        WorkingDirectory = workingDirectory;
 
-        private readonly Dictionary<string, string> _globalProperties;
-        private readonly Dictionary<string, string> _environmentVariables;
-
-        // Used for cloning
-        private readonly IDictionary<string, string> _additionalGlobalProperties;
-        private readonly IDictionary<string, string> _additionalEnvironmentVariables;
-
-        /// <summary>
-        /// Indicates that a design-time build should be performed.
-        /// </summary>
-        /// <remarks>
-        /// See https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md.
-        /// </remarks>
-        public bool DesignTime { get; }
-
-        /// <summary>
-        /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
-        /// </summary>
-        public bool Restore { get; }
-
-        public string[] TargetsToBuild { get; }
-
-        public string MsBuildExePath { get; }
-
-        public string DotnetExePath { get; }
-
-        public string WorkingDirectory { get; }
-
-        /// <summary>
-        /// Indicates if the <c>-noAutoResponse</c> argument should be set (the default is <c>true</c>).
-        /// This is required if a <c>.rsp</c> file might conflict with the command-line arguments and binary
-        /// logger that Buildalyzer uses. Setting this to false will omit the <c>-noAutoResponse</c> argument
-        /// but might also result in failed builds or incomplete information being sent to Buildalyzer.
-        /// See https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files.
-        /// </summary>
-        public bool NoAutoResponse { get; set; } = true;
-
-        public IEnumerable<string> Arguments { get; }
-
-        public IReadOnlyDictionary<string, string> GlobalProperties => _globalProperties;
-
-        public IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
-
-        public BuildEnvironment(
-            bool designTime,
-            bool restore,
-            string[] targetsToBuild,
-            string msBuildExePath,
-            string dotnetExePath,
-            IEnumerable<string> arguments,
-            IDictionary<string, string> additionalGlobalProperties = null,
-            IDictionary<string, string> additionalEnvironmentVariables = null,
-            string workingDirectory = null)
+        // Check if we've already specified a path to MSBuild
+        string envMsBuildExePath = System.Environment.GetEnvironmentVariable(Environment.EnvironmentVariables.MSBUILD_EXE_PATH);
+        MsBuildExePath = !string.IsNullOrEmpty(envMsBuildExePath) && File.Exists(envMsBuildExePath)
+            ? envMsBuildExePath : msBuildExePath;
+        if (string.IsNullOrWhiteSpace(MsBuildExePath) && string.IsNullOrWhiteSpace(dotnetExePath))
         {
-            DesignTime = designTime;
-            Restore = restore;
-            TargetsToBuild = targetsToBuild ?? throw new ArgumentNullException(nameof(targetsToBuild));
-            Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
-            WorkingDirectory = workingDirectory;
-
-            // Check if we've already specified a path to MSBuild
-            string envMsBuildExePath = System.Environment.GetEnvironmentVariable(Environment.EnvironmentVariables.MSBUILD_EXE_PATH);
-            MsBuildExePath = !string.IsNullOrEmpty(envMsBuildExePath) && File.Exists(envMsBuildExePath)
-                ? envMsBuildExePath : msBuildExePath;
-            if (string.IsNullOrWhiteSpace(MsBuildExePath) && string.IsNullOrWhiteSpace(dotnetExePath))
-            {
-                throw new ArgumentNullException(nameof(msBuildExePath));
-            }
-
-            // The dotnet path defaults to "dotnet" - if it's null then the user changed it and we should warn them
-            DotnetExePath = dotnetExePath ?? throw new ArgumentNullException(nameof(dotnetExePath));
-
-            // Set global properties
-            _globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { MsBuildProperties.ProvideCommandLineArgs, "true" },
-
-                // Workaround for a problem with resource files, see https://github.com/dotnet/sdk/issues/346#issuecomment-257654120
-                { MsBuildProperties.GenerateResourceMSBuildArchitecture, "CurrentArchitecture" },
-
-                // MsBuildProperties.SolutionDir will get set by ProjectAnalyzer
-            };
-            if (DesignTime)
-            {
-                // The actual design-time tasks aren't available outside of Visual Studio,
-                // so we can't do a "real" design-time build and have to fake it with various global properties
-                // See https://github.com/dotnet/msbuild/blob/fb700f90493a0bf47623511edf28b1d6c114e4fa/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L320
-                // To diagnose build failures in design-time mode, generate a binary log and find the filing target,
-                // then see if there's a condition or property that can be used to modify it's behavior or turn it off
-                _globalProperties.Add(MsBuildProperties.DesignTimeBuild, "true");
-                _globalProperties.Add(MsBuildProperties.BuildingProject, "false"); // Supports Framework projects: https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build
-                _globalProperties.Add(MsBuildProperties.BuildProjectReferences, "false");
-                _globalProperties.Add(MsBuildProperties.SkipCompilerExecution, "true");
-                _globalProperties.Add(MsBuildProperties.DisableRarCache, "true");
-                _globalProperties.Add(MsBuildProperties.AutoGenerateBindingRedirects, "false");
-                _globalProperties.Add(MsBuildProperties.CopyBuildOutputToOutputDirectory, "false");
-                _globalProperties.Add(MsBuildProperties.CopyOutputSymbolsToOutputDirectory, "false");
-                _globalProperties.Add(MsBuildProperties.CopyDocumentationFileToOutputDirectory, "false");
-                _globalProperties.Add(MsBuildProperties.ComputeNETCoreBuildOutputFiles, "false"); // Prevents the CreateAppHost task from running, which doesn't add the apphost.exe to the files to copy
-                _globalProperties.Add(MsBuildProperties.SkipCopyBuildProduct, "true");
-                _globalProperties.Add(MsBuildProperties.AddModules, "false");
-                _globalProperties.Add(MsBuildProperties.UseCommonOutputDirectory, "true");  // This is used in a condition to prevent copying in _CopyFilesMarkedCopyLocal
-                _globalProperties.Add(MsBuildProperties.GeneratePackageOnBuild, "false");  // Prevent NuGet.Build.Tasks.Pack.targets from running the pack targets (since we didn't build anything)
-            }
-            _additionalGlobalProperties = CopyItems(_globalProperties, additionalGlobalProperties);
-
-            // Set environment variables
-            _environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            _additionalEnvironmentVariables = CopyItems(_environmentVariables, additionalEnvironmentVariables);
+            throw new ArgumentNullException(nameof(msBuildExePath));
         }
 
-        private Dictionary<string, string> CopyItems(Dictionary<string, string> destination, IDictionary<string, string> source)
+        // The dotnet path defaults to "dotnet" - if it's null then the user changed it and we should warn them
+        DotnetExePath = dotnetExePath ?? throw new ArgumentNullException(nameof(dotnetExePath));
+
+        // Set global properties
+        _globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            if (source != null)
-            {
-                foreach (KeyValuePair<string, string> item in source)
-                {
-                    destination[item.Key] = item.Value;
-                }
+            { MsBuildProperties.ProvideCommandLineArgs, "true" },
 
-                // Copy to a new dictionary in case the source dictionary is mutated
-                return new Dictionary<string, string>(source, StringComparer.OrdinalIgnoreCase);
-            }
-            return null;
+            // Workaround for a problem with resource files, see https://github.com/dotnet/sdk/issues/346#issuecomment-257654120
+            { MsBuildProperties.GenerateResourceMSBuildArchitecture, "CurrentArchitecture" },
+
+            // MsBuildProperties.SolutionDir will get set by ProjectAnalyzer
+        };
+        if (DesignTime)
+        {
+            // The actual design-time tasks aren't available outside of Visual Studio,
+            // so we can't do a "real" design-time build and have to fake it with various global properties
+            // See https://github.com/dotnet/msbuild/blob/fb700f90493a0bf47623511edf28b1d6c114e4fa/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L320
+            // To diagnose build failures in design-time mode, generate a binary log and find the filing target,
+            // then see if there's a condition or property that can be used to modify it's behavior or turn it off
+            _globalProperties.Add(MsBuildProperties.DesignTimeBuild, "true");
+            _globalProperties.Add(MsBuildProperties.BuildingProject, "false"); // Supports Framework projects: https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build
+            _globalProperties.Add(MsBuildProperties.BuildProjectReferences, "false");
+            _globalProperties.Add(MsBuildProperties.SkipCompilerExecution, "true");
+            _globalProperties.Add(MsBuildProperties.DisableRarCache, "true");
+            _globalProperties.Add(MsBuildProperties.AutoGenerateBindingRedirects, "false");
+            _globalProperties.Add(MsBuildProperties.CopyBuildOutputToOutputDirectory, "false");
+            _globalProperties.Add(MsBuildProperties.CopyOutputSymbolsToOutputDirectory, "false");
+            _globalProperties.Add(MsBuildProperties.CopyDocumentationFileToOutputDirectory, "false");
+            _globalProperties.Add(MsBuildProperties.ComputeNETCoreBuildOutputFiles, "false"); // Prevents the CreateAppHost task from running, which doesn't add the apphost.exe to the files to copy
+            _globalProperties.Add(MsBuildProperties.SkipCopyBuildProduct, "true");
+            _globalProperties.Add(MsBuildProperties.AddModules, "false");
+            _globalProperties.Add(MsBuildProperties.UseCommonOutputDirectory, "true");  // This is used in a condition to prevent copying in _CopyFilesMarkedCopyLocal
+            _globalProperties.Add(MsBuildProperties.GeneratePackageOnBuild, "false");  // Prevent NuGet.Build.Tasks.Pack.targets from running the pack targets (since we didn't build anything)
         }
+        _additionalGlobalProperties = CopyItems(_globalProperties, additionalGlobalProperties);
 
-        /// <summary>
-        /// Clones the build environment with a different set of build targets.
-        /// </summary>
-        /// <param name="targets">
-        /// The targets that should be used to build the project.
-        /// Specifying an empty array indicates that the <see cref="ProjectAnalyzer"/> should
-        /// return a <see cref="Microsoft.Build.Execution.ProjectInstance"/> without building the project.
-        /// </param>
-        /// <returns>A new build environment with the specified targets.</returns>
-        public BuildEnvironment WithTargetsToBuild(params string[] targets) =>
-            new BuildEnvironment(
-                DesignTime,
-                Restore,
-                targets,
-                MsBuildExePath,
-                DotnetExePath,
-                Arguments,
-                _additionalGlobalProperties,
-                _additionalEnvironmentVariables,
-                WorkingDirectory);
+        // Set environment variables
+        _environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        _additionalEnvironmentVariables = CopyItems(_environmentVariables, additionalEnvironmentVariables);
     }
+
+    private Dictionary<string, string> CopyItems(Dictionary<string, string> destination, IDictionary<string, string> source)
+    {
+        if (source != null)
+        {
+            foreach (KeyValuePair<string, string> item in source)
+            {
+                destination[item.Key] = item.Value;
+            }
+
+            // Copy to a new dictionary in case the source dictionary is mutated
+            return new Dictionary<string, string>(source, StringComparer.OrdinalIgnoreCase);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Clones the build environment with a different set of build targets.
+    /// </summary>
+    /// <param name="targets">
+    /// The targets that should be used to build the project.
+    /// Specifying an empty array indicates that the <see cref="ProjectAnalyzer"/> should
+    /// return a <see cref="Microsoft.Build.Execution.ProjectInstance"/> without building the project.
+    /// </param>
+    /// <returns>A new build environment with the specified targets.</returns>
+    public BuildEnvironment WithTargetsToBuild(params string[] targets) =>
+        new BuildEnvironment(
+            DesignTime,
+            Restore,
+            targets,
+            MsBuildExePath,
+            DotnetExePath,
+            Arguments,
+            _additionalGlobalProperties,
+            _additionalEnvironmentVariables,
+            WorkingDirectory);
 }

--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -1,150 +1,147 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Environment
+namespace Buildalyzer.Environment;
+
+internal class DotnetPathResolver
 {
-    internal class DotnetPathResolver
+    private const int DefaultDotNetInfoWaitTime = 10000; // 10 seconds
+
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<DotnetPathResolver> _logger;
+
+    public DotnetPathResolver(ILoggerFactory loggerFactory)
     {
-        private const int DefaultDotNetInfoWaitTime = 10000; // 10 seconds
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory?.CreateLogger<DotnetPathResolver>();
+    }
 
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly ILogger<DotnetPathResolver> _logger;
+    // Don't cache the result because it might change project to project due to global.json
+    public string ResolvePath(string projectPath, string dotnetExePath)
+    {
+        dotnetExePath = dotnetExePath ?? "dotnet";
+        List<string> output = GetInfo(projectPath, dotnetExePath);
 
-        public DotnetPathResolver(ILoggerFactory loggerFactory)
+        // Did we get any output?
+        if (output == null || output.Count == 0)
         {
-            _loggerFactory = loggerFactory;
-            _logger = loggerFactory?.CreateLogger<DotnetPathResolver>();
-        }
-
-        // Don't cache the result because it might change project to project due to global.json
-        public string ResolvePath(string projectPath, string dotnetExePath)
-        {
-            dotnetExePath = dotnetExePath ?? "dotnet";
-            List<string> output = GetInfo(projectPath, dotnetExePath);
-
-            // Did we get any output?
-            if (output == null || output.Count == 0)
-            {
-                _logger?.LogWarning($"Could not get results from `{dotnetExePath} --info` call");
-                return null;
-            }
-
-            // Try to get a path
-            string basePath = ParseBasePath(output) ?? ParseInstalledSdksPath(output);
-            if (string.IsNullOrWhiteSpace(basePath))
-            {
-                _logger?.LogWarning($"Could not locate SDK path in `{dotnetExePath} --info` results");
-                return null;
-            }
-
-            return basePath;
-        }
-
-        private List<string> GetInfo(string projectPath, string dotnetExePath)
-        {
-            // Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
-            // running 'dotnet --info'. Otherwise, we may get localized results
-            // Also unset some MSBuild variables, see https://github.com/OmniSharp/omnisharp-roslyn/blob/df160f86ce906bc566fe3e04e38a4077bd6023b4/src/OmniSharp.Abstractions/Services/DotNetCliService.cs#L36
-            Dictionary<string, string> environmentVariables = new Dictionary<string, string>
-            {
-                { EnvironmentVariables.DOTNET_CLI_UI_LANGUAGE, "en-US" },
-                { EnvironmentVariables.MSBUILD_EXE_PATH, null },
-                { EnvironmentVariables.COREHOST_TRACE, "0" },
-                { MsBuildProperties.MSBuildExtensionsPath, null }
-            };
-
-            // global.json may change the version, so need to set working directory
-            using (ProcessRunner processRunner = new ProcessRunner(dotnetExePath, "--info", Path.GetDirectoryName(projectPath), environmentVariables, _loggerFactory))
-            {
-                int dotnetInfoWaitTime = int.TryParse(System.Environment.GetEnvironmentVariable(EnvironmentVariables.DOTNET_INFO_WAIT_TIME), out int dotnetInfoWaitTimeParsed)
-                    ? dotnetInfoWaitTimeParsed
-                    : DefaultDotNetInfoWaitTime;
-                _logger?.LogInformation($"dotnet --info wait time is {dotnetInfoWaitTime}ms");
-                processRunner.Start();
-                processRunner.WaitForExit(dotnetInfoWaitTime);
-                return processRunner.Output;
-            }
-        }
-
-        // Try to find a base path
-        internal static string ParseBasePath(List<string> lines)
-        {
-            foreach (string line in lines.Where(x => x != null))
-            {
-                int colonIndex = line.IndexOf(':');
-                if (colonIndex >= 0
-                    && line.Substring(0, colonIndex).Trim().Equals("Base Path", StringComparison.OrdinalIgnoreCase))
-                {
-                    string basePath = line.Substring(colonIndex + 1).Trim();
-
-                    // Make sure the base path matches the runtime architecture if on Windows
-                    // Note that this only works for the default installation locations under "Program Files"
-                    if (basePath.Contains(@"\Program Files\") && !System.Environment.Is64BitProcess)
-                    {
-                        string newBasePath = basePath.Replace(@"\Program Files\", @"\Program Files (x86)\");
-                        if (Directory.Exists(newBasePath))
-                        {
-                            basePath = newBasePath;
-                        }
-                    }
-                    else if (basePath.Contains(@"\Program Files (x86)\") && System.Environment.Is64BitProcess)
-                    {
-                        string newBasePath = basePath.Replace(@"\Program Files (x86)\", @"\Program Files\");
-                        if (Directory.Exists(newBasePath))
-                        {
-                            basePath = newBasePath;
-                        }
-                    }
-
-                    return basePath;
-                }
-            }
+            _logger?.LogWarning($"Could not get results from `{dotnetExePath} --info` call");
             return null;
         }
 
-        // Fallback if a base path couldn't be found (I.e., global.json version is not available)
-        internal static string ParseInstalledSdksPath(List<string> lines)
+        // Try to get a path
+        string basePath = ParseBasePath(output) ?? ParseInstalledSdksPath(output);
+        if (string.IsNullOrWhiteSpace(basePath))
         {
-            int index = lines.IndexOf(".NET SDKs installed:");
+            _logger?.LogWarning($"Could not locate SDK path in `{dotnetExePath} --info` results");
+            return null;
+        }
+
+        return basePath;
+    }
+
+    private List<string> GetInfo(string projectPath, string dotnetExePath)
+    {
+        // Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
+        // running 'dotnet --info'. Otherwise, we may get localized results
+        // Also unset some MSBuild variables, see https://github.com/OmniSharp/omnisharp-roslyn/blob/df160f86ce906bc566fe3e04e38a4077bd6023b4/src/OmniSharp.Abstractions/Services/DotNetCliService.cs#L36
+        Dictionary<string, string> environmentVariables = new Dictionary<string, string>
+        {
+            { EnvironmentVariables.DOTNET_CLI_UI_LANGUAGE, "en-US" },
+            { EnvironmentVariables.MSBUILD_EXE_PATH, null },
+            { EnvironmentVariables.COREHOST_TRACE, "0" },
+            { MsBuildProperties.MSBuildExtensionsPath, null }
+        };
+
+        // global.json may change the version, so need to set working directory
+        using (ProcessRunner processRunner = new ProcessRunner(dotnetExePath, "--info", Path.GetDirectoryName(projectPath), environmentVariables, _loggerFactory))
+        {
+            int dotnetInfoWaitTime = int.TryParse(System.Environment.GetEnvironmentVariable(EnvironmentVariables.DOTNET_INFO_WAIT_TIME), out int dotnetInfoWaitTimeParsed)
+                ? dotnetInfoWaitTimeParsed
+                : DefaultDotNetInfoWaitTime;
+            _logger?.LogInformation($"dotnet --info wait time is {dotnetInfoWaitTime}ms");
+            processRunner.Start();
+            processRunner.WaitForExit(dotnetInfoWaitTime);
+            return processRunner.Output;
+        }
+    }
+
+    // Try to find a base path
+    internal static string ParseBasePath(List<string> lines)
+    {
+        foreach (string line in lines.Where(x => x != null))
+        {
+            int colonIndex = line.IndexOf(':');
+            if (colonIndex >= 0
+                && line.Substring(0, colonIndex).Trim().Equals("Base Path", StringComparison.OrdinalIgnoreCase))
+            {
+                string basePath = line.Substring(colonIndex + 1).Trim();
+
+                // Make sure the base path matches the runtime architecture if on Windows
+                // Note that this only works for the default installation locations under "Program Files"
+                if (basePath.Contains(@"\Program Files\") && !System.Environment.Is64BitProcess)
+                {
+                    string newBasePath = basePath.Replace(@"\Program Files\", @"\Program Files (x86)\");
+                    if (Directory.Exists(newBasePath))
+                    {
+                        basePath = newBasePath;
+                    }
+                }
+                else if (basePath.Contains(@"\Program Files (x86)\") && System.Environment.Is64BitProcess)
+                {
+                    string newBasePath = basePath.Replace(@"\Program Files (x86)\", @"\Program Files\");
+                    if (Directory.Exists(newBasePath))
+                    {
+                        basePath = newBasePath;
+                    }
+                }
+
+                return basePath;
+            }
+        }
+        return null;
+    }
+
+    // Fallback if a base path couldn't be found (I.e., global.json version is not available)
+    internal static string ParseInstalledSdksPath(List<string> lines)
+    {
+        int index = lines.IndexOf(".NET SDKs installed:");
+        if (index == -1)
+        {
+            index = lines.IndexOf(".NET Core SDKs installed:");
             if (index == -1)
             {
-                index = lines.IndexOf(".NET Core SDKs installed:");
-                if (index == -1)
-                {
-                    return null;
-                }
+                return null;
+            }
+        }
+
+        index++;
+        while (true)
+        {
+            if (index >= lines.Count - 1)
+            {
+                throw new InvalidOperationException("Could not find the .NET SDK.");
+            }
+
+            // Not a version number or an empty string?
+            string temp = lines[index].Trim();
+            if (string.IsNullOrWhiteSpace(temp) || !char.IsDigit(temp[0]))
+            {
+                index--;
+                break;
             }
 
             index++;
-            while (true)
-            {
-                if (index >= lines.Count - 1)
-                {
-                    throw new InvalidOperationException("Could not find the .NET SDK.");
-                }
-
-                // Not a version number or an empty string?
-                string temp = lines[index].Trim();
-                if (string.IsNullOrWhiteSpace(temp) || !char.IsDigit(temp[0]))
-                {
-                    index--;
-                    break;
-                }
-
-                index++;
-            }
-
-            string[] segments = lines[index]
-                .Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries)
-                .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Select(x => x.Trim())
-                .ToArray();
-            return $"{segments[1]}{Path.DirectorySeparatorChar}{segments[0]}{Path.DirectorySeparatorChar}";
         }
+
+        string[] segments = lines[index]
+            .Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .ToArray();
+        return $"{segments[1]}{Path.DirectorySeparatorChar}{segments[0]}{Path.DirectorySeparatorChar}";
     }
 }

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -3,209 +3,206 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Xml.Linq;
 using Buildalyzer.Construction;
 using Microsoft.Build.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Environment
+namespace Buildalyzer.Environment;
+
+public class EnvironmentFactory
 {
-    public class EnvironmentFactory
+    private readonly IAnalyzerManager _manager;
+    private readonly IProjectFile _projectFile;
+    private readonly ILogger<EnvironmentFactory> _logger;
+
+    internal EnvironmentFactory(IAnalyzerManager manager, IProjectFile projectFile)
     {
-        private readonly IAnalyzerManager _manager;
-        private readonly IProjectFile _projectFile;
-        private readonly ILogger<EnvironmentFactory> _logger;
-
-        internal EnvironmentFactory(IAnalyzerManager manager, IProjectFile projectFile)
-        {
-            _manager = manager;
-            _projectFile = projectFile;
-            _logger = _manager.LoggerFactory?.CreateLogger<EnvironmentFactory>();
-        }
-
-        public BuildEnvironment GetBuildEnvironment() =>
-            GetBuildEnvironment(null, null);
-
-        public BuildEnvironment GetBuildEnvironment(string targetFramework) =>
-            GetBuildEnvironment(targetFramework, null);
-
-        public BuildEnvironment GetBuildEnvironment(EnvironmentOptions options) =>
-            GetBuildEnvironment(null, options);
-
-        public BuildEnvironment GetBuildEnvironment(string targetFramework, EnvironmentOptions options)
-        {
-            options = options ?? new EnvironmentOptions();
-            BuildEnvironment buildEnvironment;
-
-            // Use the .NET Framework if that's the preference
-            // ...or if this project file uses a target known to require .NET Framework
-            // ...or if this project ONLY targets .NET Framework ("net" followed by a digit)
-            if (options.Preference == EnvironmentPreference.Framework
-                || _projectFile.RequiresNetFramework
-                || (_projectFile.UsesSdk && OnlyTargetsFramework(targetFramework)))
-            {
-                buildEnvironment = CreateFrameworkEnvironment(options) ?? CreateCoreEnvironment(options);
-            }
-            else
-            {
-                // Otherwise, use a Core environment if it can be found
-                buildEnvironment = CreateCoreEnvironment(options) ?? CreateFrameworkEnvironment(options);
-            }
-
-            return buildEnvironment ?? throw new InvalidOperationException("Could not find build environment");
-        }
-
-        // Based on code from OmniSharp
-        // https://github.com/OmniSharp/omnisharp-roslyn/blob/78ccc8b4376c73da282a600ac6fb10fce8620b52/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
-        private BuildEnvironment CreateCoreEnvironment(EnvironmentOptions options)
-        {
-            // Get paths
-            DotnetPathResolver pathResolver = new DotnetPathResolver(_manager.LoggerFactory);
-            string dotnetPath = pathResolver.ResolvePath(_projectFile.Path, options.DotnetExePath);
-            if (dotnetPath == null)
-            {
-                return null;
-            }
-
-            string msBuildExePath = Path.Combine(dotnetPath, "MSBuild.dll");
-            if (options != null && options.EnvironmentVariables.ContainsKey(EnvironmentVariables.MSBUILD_EXE_PATH))
-            {
-                msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
-            }
-
-            // Clone the options global properties dictionary so we can add to it
-            Dictionary<string, string> additionalGlobalProperties = new Dictionary<string, string>(options.GlobalProperties);
-
-            // Required to force CoreCompile target when it calculates everything is already built
-            // This can happen if the file wasn't previously generated (Clean only cleans what was in that file)
-            // Only required if we're not running a design-time build (otherwise the targets will be replaced anyway)
-            if (options.TargetsToBuild.Contains("Clean", StringComparer.OrdinalIgnoreCase))
-            {
-                additionalGlobalProperties.Add(MsBuildProperties.NonExistentFile, Path.Combine("__NonExistentSubDir__", "__NonExistentFile__"));
-            }
-
-            // Clone the options global properties dictionary so we can add to it
-            Dictionary<string, string> additionalEnvironmentVariables = new Dictionary<string, string>(options.EnvironmentVariables);
-
-            // (Re)set the environment variables that dotnet sets
-            // See https://github.com/dotnet/cli/blob/0a4ad813ff971f549d34ac4ebc6c8cca9a741c36/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs#L22-L28
-            // Especially important if a global.json is used because dotnet may set these to the latest, but then we'll call a msbuild.dll for the global.json version
-            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
-            {
-                additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
-            }
-            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
-            {
-                additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
-            }
-            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.COREHOST_TRACE))
-            {
-                additionalEnvironmentVariables.Add(EnvironmentVariables.COREHOST_TRACE, "0");
-            }
-            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.DOTNET_HOST_PATH))
-            {
-                additionalEnvironmentVariables.Add(
-                    EnvironmentVariables.DOTNET_HOST_PATH,
-                    Path.GetFullPath(Path.Combine(dotnetPath, "..", "..", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet")));
-            }
-
-            return new BuildEnvironment(
-                options.DesignTime,
-                options.Restore,
-                options.TargetsToBuild.ToArray(),
-                msBuildExePath,
-                options.DotnetExePath,
-                options.Arguments,
-                additionalGlobalProperties,
-                additionalEnvironmentVariables,
-                options.WorkingDirectory);
-        }
-
-        private BuildEnvironment CreateFrameworkEnvironment(EnvironmentOptions options)
-        {
-            // Clone the options global properties dictionary so we can add to it
-            Dictionary<string, string> additionalGlobalProperties = new Dictionary<string, string>(options.GlobalProperties);
-
-            // Required to force CoreCompile target when it calculates everything is already built
-            // This can happen if the file wasn't previously generated (Clean only cleans what was in that file)
-            // Only required if we're not running a design-time build (otherwise the targets will be replaced anyway)
-            if (options.TargetsToBuild.Contains("Clean", StringComparer.OrdinalIgnoreCase))
-            {
-                additionalGlobalProperties.Add(MsBuildProperties.NonExistentFile, Path.Combine("__NonExistentSubDir__", "__NonExistentFile__"));
-            }
-
-            string msBuildExePath;
-            if (options != null && options.EnvironmentVariables.ContainsKey(EnvironmentVariables.MSBUILD_EXE_PATH))
-            {
-                msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
-            }
-            else if (!GetFrameworkMsBuildExePath(out msBuildExePath))
-            {
-                _logger?.LogWarning("Couldn't find a .NET Framework MSBuild path");
-                return null;
-            }
-
-            // This is required to trigger NuGet package resolution and regeneration of project.assets.json
-            additionalGlobalProperties.Add(MsBuildProperties.ResolveNuGetPackages, "true");
-
-            return new BuildEnvironment(
-                options.DesignTime,
-                options.Restore,
-                options.TargetsToBuild.ToArray(),
-                msBuildExePath,
-                options.DotnetExePath,
-                options.Arguments,
-                additionalGlobalProperties,
-                options.EnvironmentVariables,
-                options.WorkingDirectory);
-        }
-
-        private bool GetFrameworkMsBuildExePath(out string msBuildExePath)
-        {
-            msBuildExePath = ToolLocationHelper.GetPathToBuildToolsFile("msbuild.exe", ToolLocationHelper.CurrentToolsVersion);
-            if (string.IsNullOrEmpty(msBuildExePath))
-            {
-                // Could not find the tools path, possibly due to https://github.com/Microsoft/msbuild/issues/2369
-                // Try to poll for it. From https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/4649f55f900a324421bad5a714a2584926a02138/src/StructuredLogViewer/MSBuildLocator.cs
-                List<DirectoryInfo> msBuildDirectories = new List<DirectoryInfo>();
-
-                // Search in the x86 program files
-                string programFilesX86 = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
-                DirectoryInfo vsX86Directory = new DirectoryInfo(Path.Combine(programFilesX86, "Microsoft Visual Studio"));
-                if (vsX86Directory.Exists)
-                {
-                    msBuildDirectories.AddRange(vsX86Directory.GetDirectories("MSBuild", SearchOption.AllDirectories));
-                }
-
-                // Also search in x64 since VS 2022 and on is now 64-bit
-                string programFiles = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles);
-                DirectoryInfo vsDirectory = new DirectoryInfo(Path.Combine(programFiles, "Microsoft Visual Studio"));
-                if (vsDirectory.Exists)
-                {
-                    msBuildDirectories.AddRange(vsDirectory.GetDirectories("MSBuild", SearchOption.AllDirectories));
-                }
-
-                // Now order by write time to get the latest MSBuild
-                msBuildExePath = msBuildDirectories
-                    .SelectMany(msBuildDir => msBuildDir.GetFiles("MSBuild.exe", SearchOption.AllDirectories))
-                    .OrderByDescending(msBuild => msBuild.LastWriteTimeUtc)
-                    .FirstOrDefault()?.FullName;
-            }
-            return !string.IsNullOrEmpty(msBuildExePath);
-        }
-
-        private bool OnlyTargetsFramework(string targetFramework) =>
-            targetFramework == null ? _projectFile.TargetFrameworks.All(x => IsFrameworkTargetFramework(x)) : IsFrameworkTargetFramework(targetFramework);
-
-        // Internal for testing
-        // Because the .NET Core/.NET 5 TFMs are better defined, we just check if this is one of them and then negate
-        internal static bool IsFrameworkTargetFramework(string targetFramework) =>
-            !(targetFramework.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase)
-            || targetFramework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase)
-            || (targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
-                && targetFramework.Length > 3
-                && int.TryParse(new string(new[] { targetFramework[3] }), out int version)
-                && version >= 5));
+        _manager = manager;
+        _projectFile = projectFile;
+        _logger = _manager.LoggerFactory?.CreateLogger<EnvironmentFactory>();
     }
+
+    public BuildEnvironment GetBuildEnvironment() =>
+        GetBuildEnvironment(null, null);
+
+    public BuildEnvironment GetBuildEnvironment(string targetFramework) =>
+        GetBuildEnvironment(targetFramework, null);
+
+    public BuildEnvironment GetBuildEnvironment(EnvironmentOptions options) =>
+        GetBuildEnvironment(null, options);
+
+    public BuildEnvironment GetBuildEnvironment(string targetFramework, EnvironmentOptions options)
+    {
+        options = options ?? new EnvironmentOptions();
+        BuildEnvironment buildEnvironment;
+
+        // Use the .NET Framework if that's the preference
+        // ...or if this project file uses a target known to require .NET Framework
+        // ...or if this project ONLY targets .NET Framework ("net" followed by a digit)
+        if (options.Preference == EnvironmentPreference.Framework
+            || _projectFile.RequiresNetFramework
+            || (_projectFile.UsesSdk && OnlyTargetsFramework(targetFramework)))
+        {
+            buildEnvironment = CreateFrameworkEnvironment(options) ?? CreateCoreEnvironment(options);
+        }
+        else
+        {
+            // Otherwise, use a Core environment if it can be found
+            buildEnvironment = CreateCoreEnvironment(options) ?? CreateFrameworkEnvironment(options);
+        }
+
+        return buildEnvironment ?? throw new InvalidOperationException("Could not find build environment");
+    }
+
+    // Based on code from OmniSharp
+    // https://github.com/OmniSharp/omnisharp-roslyn/blob/78ccc8b4376c73da282a600ac6fb10fce8620b52/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
+    private BuildEnvironment CreateCoreEnvironment(EnvironmentOptions options)
+    {
+        // Get paths
+        DotnetPathResolver pathResolver = new DotnetPathResolver(_manager.LoggerFactory);
+        string dotnetPath = pathResolver.ResolvePath(_projectFile.Path, options.DotnetExePath);
+        if (dotnetPath == null)
+        {
+            return null;
+        }
+
+        string msBuildExePath = Path.Combine(dotnetPath, "MSBuild.dll");
+        if (options != null && options.EnvironmentVariables.ContainsKey(EnvironmentVariables.MSBUILD_EXE_PATH))
+        {
+            msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
+        }
+
+        // Clone the options global properties dictionary so we can add to it
+        Dictionary<string, string> additionalGlobalProperties = new Dictionary<string, string>(options.GlobalProperties);
+
+        // Required to force CoreCompile target when it calculates everything is already built
+        // This can happen if the file wasn't previously generated (Clean only cleans what was in that file)
+        // Only required if we're not running a design-time build (otherwise the targets will be replaced anyway)
+        if (options.TargetsToBuild.Contains("Clean", StringComparer.OrdinalIgnoreCase))
+        {
+            additionalGlobalProperties.Add(MsBuildProperties.NonExistentFile, Path.Combine("__NonExistentSubDir__", "__NonExistentFile__"));
+        }
+
+        // Clone the options global properties dictionary so we can add to it
+        Dictionary<string, string> additionalEnvironmentVariables = new Dictionary<string, string>(options.EnvironmentVariables);
+
+        // (Re)set the environment variables that dotnet sets
+        // See https://github.com/dotnet/cli/blob/0a4ad813ff971f549d34ac4ebc6c8cca9a741c36/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs#L22-L28
+        // Especially important if a global.json is used because dotnet may set these to the latest, but then we'll call a msbuild.dll for the global.json version
+        if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
+        {
+            additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
+        }
+        if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
+        {
+            additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
+        }
+        if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.COREHOST_TRACE))
+        {
+            additionalEnvironmentVariables.Add(EnvironmentVariables.COREHOST_TRACE, "0");
+        }
+        if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.DOTNET_HOST_PATH))
+        {
+            additionalEnvironmentVariables.Add(
+                EnvironmentVariables.DOTNET_HOST_PATH,
+                Path.GetFullPath(Path.Combine(dotnetPath, "..", "..", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet")));
+        }
+
+        return new BuildEnvironment(
+            options.DesignTime,
+            options.Restore,
+            options.TargetsToBuild.ToArray(),
+            msBuildExePath,
+            options.DotnetExePath,
+            options.Arguments,
+            additionalGlobalProperties,
+            additionalEnvironmentVariables,
+            options.WorkingDirectory);
+    }
+
+    private BuildEnvironment CreateFrameworkEnvironment(EnvironmentOptions options)
+    {
+        // Clone the options global properties dictionary so we can add to it
+        Dictionary<string, string> additionalGlobalProperties = new Dictionary<string, string>(options.GlobalProperties);
+
+        // Required to force CoreCompile target when it calculates everything is already built
+        // This can happen if the file wasn't previously generated (Clean only cleans what was in that file)
+        // Only required if we're not running a design-time build (otherwise the targets will be replaced anyway)
+        if (options.TargetsToBuild.Contains("Clean", StringComparer.OrdinalIgnoreCase))
+        {
+            additionalGlobalProperties.Add(MsBuildProperties.NonExistentFile, Path.Combine("__NonExistentSubDir__", "__NonExistentFile__"));
+        }
+
+        string msBuildExePath;
+        if (options != null && options.EnvironmentVariables.ContainsKey(EnvironmentVariables.MSBUILD_EXE_PATH))
+        {
+            msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
+        }
+        else if (!GetFrameworkMsBuildExePath(out msBuildExePath))
+        {
+            _logger?.LogWarning("Couldn't find a .NET Framework MSBuild path");
+            return null;
+        }
+
+        // This is required to trigger NuGet package resolution and regeneration of project.assets.json
+        additionalGlobalProperties.Add(MsBuildProperties.ResolveNuGetPackages, "true");
+
+        return new BuildEnvironment(
+            options.DesignTime,
+            options.Restore,
+            options.TargetsToBuild.ToArray(),
+            msBuildExePath,
+            options.DotnetExePath,
+            options.Arguments,
+            additionalGlobalProperties,
+            options.EnvironmentVariables,
+            options.WorkingDirectory);
+    }
+
+    private bool GetFrameworkMsBuildExePath(out string msBuildExePath)
+    {
+        msBuildExePath = ToolLocationHelper.GetPathToBuildToolsFile("msbuild.exe", ToolLocationHelper.CurrentToolsVersion);
+        if (string.IsNullOrEmpty(msBuildExePath))
+        {
+            // Could not find the tools path, possibly due to https://github.com/Microsoft/msbuild/issues/2369
+            // Try to poll for it. From https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/4649f55f900a324421bad5a714a2584926a02138/src/StructuredLogViewer/MSBuildLocator.cs
+            List<DirectoryInfo> msBuildDirectories = new List<DirectoryInfo>();
+
+            // Search in the x86 program files
+            string programFilesX86 = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
+            DirectoryInfo vsX86Directory = new DirectoryInfo(Path.Combine(programFilesX86, "Microsoft Visual Studio"));
+            if (vsX86Directory.Exists)
+            {
+                msBuildDirectories.AddRange(vsX86Directory.GetDirectories("MSBuild", SearchOption.AllDirectories));
+            }
+
+            // Also search in x64 since VS 2022 and on is now 64-bit
+            string programFiles = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles);
+            DirectoryInfo vsDirectory = new DirectoryInfo(Path.Combine(programFiles, "Microsoft Visual Studio"));
+            if (vsDirectory.Exists)
+            {
+                msBuildDirectories.AddRange(vsDirectory.GetDirectories("MSBuild", SearchOption.AllDirectories));
+            }
+
+            // Now order by write time to get the latest MSBuild
+            msBuildExePath = msBuildDirectories
+                .SelectMany(msBuildDir => msBuildDir.GetFiles("MSBuild.exe", SearchOption.AllDirectories))
+                .OrderByDescending(msBuild => msBuild.LastWriteTimeUtc)
+                .FirstOrDefault()?.FullName;
+        }
+        return !string.IsNullOrEmpty(msBuildExePath);
+    }
+
+    private bool OnlyTargetsFramework(string targetFramework) =>
+        targetFramework == null ? _projectFile.TargetFrameworks.All(x => IsFrameworkTargetFramework(x)) : IsFrameworkTargetFramework(targetFramework);
+
+    // Internal for testing
+    // Because the .NET Core/.NET 5 TFMs are better defined, we just check if this is one of them and then negate
+    internal static bool IsFrameworkTargetFramework(string targetFramework) =>
+        !(targetFramework.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase)
+        || targetFramework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase)
+        || (targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+            && targetFramework.Length > 3
+            && int.TryParse(new string(new[] { targetFramework[3] }), out int version)
+            && version >= 5));
 }

--- a/src/Buildalyzer/Environment/EnvironmentOptions.cs
+++ b/src/Buildalyzer/Environment/EnvironmentOptions.cs
@@ -1,68 +1,67 @@
 ﻿using System.Collections.Generic;
 
-namespace Buildalyzer.Environment
+namespace Buildalyzer.Environment;
+
+public class EnvironmentOptions
 {
-    public class EnvironmentOptions
-    {
-        /// <summary>
-        /// Indicates a preferences towards the build environment to use.
-        /// The default is a preference for the .NET Core SDK.
-        /// </summary>
-        public EnvironmentPreference Preference { get; set; } = EnvironmentPreference.Core;
+    /// <summary>
+    /// Indicates a preferences towards the build environment to use.
+    /// The default is a preference for the .NET Core SDK.
+    /// </summary>
+    public EnvironmentPreference Preference { get; set; } = EnvironmentPreference.Core;
 
-        /// <summary>
-        /// The default targets to build.
-        /// </summary>
-        public List<string> TargetsToBuild { get; } = new List<string> { "Clean", "Build" };
+    /// <summary>
+    /// The default targets to build.
+    /// </summary>
+    public List<string> TargetsToBuild { get; } = new List<string> { "Clean", "Build" };
 
-        /// <summary>
-        /// Indicates that a design-time build should be performed.
-        /// The default value is <c>true</c>. Note that when performing
-        /// a design-time build, the <see cref="TargetsToBuild"/> will
-        /// be ignored and the design-time targets will be used instead.
-        /// </summary>
-        /// <remarks>
-        /// See https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md.
-        /// </remarks>
-        public bool DesignTime { get; set; } = true;
+    /// <summary>
+    /// Indicates that a design-time build should be performed.
+    /// The default value is <c>true</c>. Note that when performing
+    /// a design-time build, the <see cref="TargetsToBuild"/> will
+    /// be ignored and the design-time targets will be used instead.
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md.
+    /// </remarks>
+    public bool DesignTime { get; set; } = true;
 
-        /// <summary>
-        /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
-        /// </summary>
-        /// <remarks>
-        /// See https://github.com/Microsoft/msbuild/pull/2414.
-        /// </remarks>
-        public bool Restore { get; set; } = true;
+    /// <summary>
+    /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/Microsoft/msbuild/pull/2414.
+    /// </remarks>
+    public bool Restore { get; set; } = true;
 
-        /// <summary>
-        /// The full path to the <c>dotnet</c> executable you want to use for the build when building
-        /// projects using the .NET Core SDK. Defaults to <c>dotnet</c> which will look in folders
-        /// specified in the path environment variable.
-        /// </summary>
-        /// <remarks>
-        /// Set this to something else to customize the .NET Core runtime you want to use (I.e., preview versions).
-        /// </remarks>
-        public string DotnetExePath { get; set; } = "dotnet";
+    /// <summary>
+    /// The full path to the <c>dotnet</c> executable you want to use for the build when building
+    /// projects using the .NET Core SDK. Defaults to <c>dotnet</c> which will look in folders
+    /// specified in the path environment variable.
+    /// </summary>
+    /// <remarks>
+    /// Set this to something else to customize the .NET Core runtime you want to use (I.e., preview versions).
+    /// </remarks>
+    public string DotnetExePath { get; set; } = "dotnet";
 
-        /// <summary>
-        /// The global MSBuild properties to set.
-        /// </summary>
-        public IDictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>();
+    /// <summary>
+    /// The global MSBuild properties to set.
+    /// </summary>
+    public IDictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>();
 
-        /// <summary>
-        /// Environment variables to set.
-        /// </summary>
-        public IDictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
+    /// <summary>
+    /// Environment variables to set.
+    /// </summary>
+    public IDictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
 
-        /// <summary>
-        /// Additional MSBuild command-line arguments to use.
-        /// </summary>
-        public IList<string> Arguments { get; } = new List<string>();
+    /// <summary>
+    /// Additional MSBuild command-line arguments to use.
+    /// </summary>
+    public IList<string> Arguments { get; } = new List<string>();
 
-        /// <summary>
-        /// Specifies an alternate working directory to use for the build instead of the project file directory.
-        /// Set to (or keep as) null to use the directory of the project file being built as the working directory.
-        /// </summary>
-        public string WorkingDirectory { get; set; }
-    }
+    /// <summary>
+    /// Specifies an alternate working directory to use for the build instead of the project file directory.
+    /// Set to (or keep as) null to use the directory of the project file being built as the working directory.
+    /// </summary>
+    public string WorkingDirectory { get; set; }
 }

--- a/src/Buildalyzer/Environment/EnvironmentPreference.cs
+++ b/src/Buildalyzer/Environment/EnvironmentPreference.cs
@@ -1,19 +1,18 @@
-﻿namespace Buildalyzer.Environment
-{
-    public enum EnvironmentPreference
-    {
-        /// <summary>
-        /// This will prefer the .NET Core SDK if it's available and will
-        /// use the .NET Framework build tools if the project type is known
-        /// not to support the .NET Core SDK or the .NET Core SDK can't be found.
-        /// </summary>
-        Core,
+﻿namespace Buildalyzer.Environment;
 
-        /// <summary>
-        /// This will prefer the .NET Framework build tools if they're available and will
-        /// use the .NET Code SDK if the project type is known
-        /// not to support the .NET Framework build tools or the .NET Framework build tools can't be found.
-        /// </summary>
-        Framework
-    }
+public enum EnvironmentPreference
+{
+    /// <summary>
+    /// This will prefer the .NET Core SDK if it's available and will
+    /// use the .NET Framework build tools if the project type is known
+    /// not to support the .NET Core SDK or the .NET Core SDK can't be found.
+    /// </summary>
+    Core,
+
+    /// <summary>
+    /// This will prefer the .NET Framework build tools if they're available and will
+    /// use the .NET Code SDK if the project type is known
+    /// not to support the .NET Framework build tools or the .NET Framework build tools can't be found.
+    /// </summary>
+    Framework
 }

--- a/src/Buildalyzer/Environment/EnvironmentVariables.cs
+++ b/src/Buildalyzer/Environment/EnvironmentVariables.cs
@@ -1,18 +1,17 @@
-﻿namespace Buildalyzer.Environment
+﻿namespace Buildalyzer.Environment;
+
+public static class EnvironmentVariables
 {
-    public static class EnvironmentVariables
-    {
 #pragma warning disable SA1310 // Field names should not contain underscore
 #pragma warning disable CA1707 // Remove the underscores from member name
-        public const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
-        public const string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
-        public const string COREHOST_TRACE = nameof(COREHOST_TRACE);
-        public const string DOTNET_HOST_PATH = nameof(DOTNET_HOST_PATH);
-        public const string DOTNET_INFO_WAIT_TIME = nameof(DOTNET_INFO_WAIT_TIME);
+    public const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
+    public const string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
+    public const string COREHOST_TRACE = nameof(COREHOST_TRACE);
+    public const string DOTNET_HOST_PATH = nameof(DOTNET_HOST_PATH);
+    public const string DOTNET_INFO_WAIT_TIME = nameof(DOTNET_INFO_WAIT_TIME);
 #pragma warning restore CA1707
 #pragma warning restore SA1310 // Field names should not contain underscore
-        public const string MSBUILDDISABLENODEREUSE = nameof(MSBUILDDISABLENODEREUSE);
-        public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
-        public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
-    }
+    public const string MSBUILDDISABLENODEREUSE = nameof(MSBUILDDISABLENODEREUSE);
+    public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
+    public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
 }

--- a/src/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/Buildalyzer/Environment/MsBuildProperties.cs
@@ -1,44 +1,43 @@
-﻿namespace Buildalyzer.Environment
+﻿namespace Buildalyzer.Environment;
+
+public static class MsBuildProperties
 {
-    public static class MsBuildProperties
-    {
-        // MSBuild Project Loading
-        public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
-        public const string MSBuildExtensionsPath32 = nameof(MSBuildExtensionsPath32);
-        public const string MSBuildExtensionsPath64 = nameof(MSBuildExtensionsPath64);
-        public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
-        public const string RoslynTargetsPath = nameof(RoslynTargetsPath);
-        public const string SolutionDir = nameof(SolutionDir);
-        public const string TargetFramework = nameof(TargetFramework);
+    // MSBuild Project Loading
+    public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
+    public const string MSBuildExtensionsPath32 = nameof(MSBuildExtensionsPath32);
+    public const string MSBuildExtensionsPath64 = nameof(MSBuildExtensionsPath64);
+    public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
+    public const string RoslynTargetsPath = nameof(RoslynTargetsPath);
+    public const string SolutionDir = nameof(SolutionDir);
+    public const string TargetFramework = nameof(TargetFramework);
 
-        // Design-time Build
-        public const string DesignTimeBuild = nameof(DesignTimeBuild); // New project system (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
-        public const string BuildingProject = nameof(BuildingProject); // Legacy (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
-        public const string BuildProjectReferences = nameof(BuildProjectReferences);
-        public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
-        public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
-        public const string DisableRarCache = nameof(DisableRarCache);
-        public const string AutoGenerateBindingRedirects = nameof(AutoGenerateBindingRedirects);
-        public const string CopyBuildOutputToOutputDirectory = nameof(CopyBuildOutputToOutputDirectory);
-        public const string CopyOutputSymbolsToOutputDirectory = nameof(CopyOutputSymbolsToOutputDirectory);
-        public const string CopyDocumentationFileToOutputDirectory = nameof(CopyDocumentationFileToOutputDirectory);
-        public const string ComputeNETCoreBuildOutputFiles = nameof(ComputeNETCoreBuildOutputFiles);
-        public const string SkipCopyBuildProduct = nameof(SkipCopyBuildProduct);
-        public const string AddModules = nameof(AddModules);
-        public const string UseCommonOutputDirectory = nameof(UseCommonOutputDirectory);
-        public const string GeneratePackageOnBuild = nameof(GeneratePackageOnBuild);
+    // Design-time Build
+    public const string DesignTimeBuild = nameof(DesignTimeBuild); // New project system (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
+    public const string BuildingProject = nameof(BuildingProject); // Legacy (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
+    public const string BuildProjectReferences = nameof(BuildProjectReferences);
+    public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
+    public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
+    public const string DisableRarCache = nameof(DisableRarCache);
+    public const string AutoGenerateBindingRedirects = nameof(AutoGenerateBindingRedirects);
+    public const string CopyBuildOutputToOutputDirectory = nameof(CopyBuildOutputToOutputDirectory);
+    public const string CopyOutputSymbolsToOutputDirectory = nameof(CopyOutputSymbolsToOutputDirectory);
+    public const string CopyDocumentationFileToOutputDirectory = nameof(CopyDocumentationFileToOutputDirectory);
+    public const string ComputeNETCoreBuildOutputFiles = nameof(ComputeNETCoreBuildOutputFiles);
+    public const string SkipCopyBuildProduct = nameof(SkipCopyBuildProduct);
+    public const string AddModules = nameof(AddModules);
+    public const string UseCommonOutputDirectory = nameof(UseCommonOutputDirectory);
+    public const string GeneratePackageOnBuild = nameof(GeneratePackageOnBuild);
 
-        // .NET Framework code analysis rulesets
-        public const string CodeAnalysisRuleDirectories = nameof(CodeAnalysisRuleDirectories);
-        public const string CodeAnalysisRuleSetDirectories = nameof(CodeAnalysisRuleSetDirectories);
+    // .NET Framework code analysis rulesets
+    public const string CodeAnalysisRuleDirectories = nameof(CodeAnalysisRuleDirectories);
+    public const string CodeAnalysisRuleSetDirectories = nameof(CodeAnalysisRuleSetDirectories);
 
-        // NuGet
-        public const string ResolveNuGetPackages = nameof(ResolveNuGetPackages);
-        public const string NuGetRestoreTargets = nameof(NuGetRestoreTargets);
+    // NuGet
+    public const string ResolveNuGetPackages = nameof(ResolveNuGetPackages);
+    public const string NuGetRestoreTargets = nameof(NuGetRestoreTargets);
 
-        // Others
-        public const string GenerateResourceMSBuildArchitecture = nameof(GenerateResourceMSBuildArchitecture);
-        public const string NonExistentFile = nameof(NonExistentFile);
-        public const string NoAutoResponse = nameof(NoAutoResponse); // See https://github.com/daveaglick/Buildalyzer/issues/211
-    }
+    // Others
+    public const string GenerateResourceMSBuildArchitecture = nameof(GenerateResourceMSBuildArchitecture);
+    public const string NonExistentFile = nameof(NonExistentFile);
+    public const string NoAutoResponse = nameof(NoAutoResponse); // See https://github.com/daveaglick/Buildalyzer/issues/211
 }

--- a/src/Buildalyzer/Environment/ProcessRunner.cs
+++ b/src/Buildalyzer/Environment/ProcessRunner.cs
@@ -1,112 +1,108 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Environment
+namespace Buildalyzer.Environment;
+
+internal class ProcessRunner : IDisposable
 {
-    internal class ProcessRunner : IDisposable
+    private readonly ILogger<ProcessRunner> _logger;
+
+    public List<string> Output { get; } = new List<string>();
+    public List<string> Error { get; } = new List<string>();
+    public int ExitCode => Process.ExitCode;
+
+    private Process Process { get; }
+
+    public Action Exited { get; set; }
+
+    public ProcessRunner(
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        Dictionary<string, string> environmentVariables,
+        ILoggerFactory loggerFactory)
     {
-        private readonly ILogger<ProcessRunner> _logger;
-
-        public List<string> Output { get; } = new List<string>();
-        public List<string> Error { get; } = new List<string>();
-        public int ExitCode => Process.ExitCode;
-
-        private Process Process { get; }
-
-        public Action Exited { get; set; }
-
-        public ProcessRunner(
-            string fileName,
-            string arguments,
-            string workingDirectory,
-            Dictionary<string, string> environmentVariables,
-            ILoggerFactory loggerFactory)
+        _logger = loggerFactory?.CreateLogger<ProcessRunner>();
+        Process = new Process
         {
-            _logger = loggerFactory?.CreateLogger<ProcessRunner>();
-            Process = new Process
+            StartInfo =
             {
-                StartInfo =
-                {
-                    FileName = fileName,
-                    Arguments = arguments,
-                    WorkingDirectory = workingDirectory,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                }
-            };
-
-            // Copy over environment variables
-            if (environmentVariables != null)
-            {
-                foreach (KeyValuePair<string, string> variable in environmentVariables)
-                {
-                    Process.StartInfo.Environment[variable.Key] = variable.Value;
-                    Process.StartInfo.EnvironmentVariables[variable.Key] = variable.Value;
-                }
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             }
+        };
 
-            Process.EnableRaisingEvents = true;  // Raises Process.Exited immediately instead of when checked via .WaitForExit() or .HasExited
-            Process.Exited += ProcessExited;
-
-            Process.OutputDataReceived += (_, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    Output.Add(e.Data);
-                    _logger?.LogDebug(e.Data + System.Environment.NewLine);
-                }
-            };
-            Process.ErrorDataReceived += (_, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    Error.Add(e.Data);
-                    _logger?.LogError(e.Data + System.Environment.NewLine);
-                }
-            };
-        }
-
-        public ProcessRunner Start()
+        // Copy over environment variables
+        if (environmentVariables != null)
         {
-            Process.Start();
-            Process.BeginOutputReadLine();
-            Process.BeginErrorReadLine();
-            _logger?.LogDebug($"{System.Environment.NewLine}Started process {Process.Id}: \"{Process.StartInfo.FileName}\" {Process.StartInfo.Arguments}{System.Environment.NewLine}");
-            return this;
-        }
-
-        private void ProcessExited(object sender, EventArgs e)
-        {
-            Exited?.Invoke();
-            _logger?.LogDebug($"Process {Process.Id} exited with code {Process.ExitCode}{System.Environment.NewLine}{System.Environment.NewLine}");
-        }
-
-        public void WaitForExit() => Process.WaitForExit();
-
-        public bool WaitForExit(int timeout)
-        {
-            bool exited = Process.WaitForExit(timeout);
-            if (exited)
+            foreach (KeyValuePair<string, string> variable in environmentVariables)
             {
-                // To ensure that asynchronous event handling has been completed, call the WaitForExit() overload that takes no parameter after receiving a true from this overload.
-                // From https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?redirectedfrom=MSDN&view=netcore-3.1#System_Diagnostics_Process_WaitForExit_System_Int32_
-                // See also https://github.com/dotnet/runtime/issues/27128
-                Process.WaitForExit();
+                Process.StartInfo.Environment[variable.Key] = variable.Value;
+                Process.StartInfo.EnvironmentVariables[variable.Key] = variable.Value;
             }
-            return exited;
         }
 
-        public void Dispose()
+        Process.EnableRaisingEvents = true;  // Raises Process.Exited immediately instead of when checked via .WaitForExit() or .HasExited
+        Process.Exited += ProcessExited;
+
+        Process.OutputDataReceived += (_, e) =>
         {
-            Process.Exited -= ProcessExited;
-            Process.Close();
+            if (!string.IsNullOrEmpty(e.Data))
+            {
+                Output.Add(e.Data);
+                _logger?.LogDebug(e.Data + System.Environment.NewLine);
+            }
+        };
+        Process.ErrorDataReceived += (_, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+            {
+                Error.Add(e.Data);
+                _logger?.LogError(e.Data + System.Environment.NewLine);
+            }
+        };
+    }
+
+    public ProcessRunner Start()
+    {
+        Process.Start();
+        Process.BeginOutputReadLine();
+        Process.BeginErrorReadLine();
+        _logger?.LogDebug($"{System.Environment.NewLine}Started process {Process.Id}: \"{Process.StartInfo.FileName}\" {Process.StartInfo.Arguments}{System.Environment.NewLine}");
+        return this;
+    }
+
+    private void ProcessExited(object sender, EventArgs e)
+    {
+        Exited?.Invoke();
+        _logger?.LogDebug($"Process {Process.Id} exited with code {Process.ExitCode}{System.Environment.NewLine}{System.Environment.NewLine}");
+    }
+
+    public void WaitForExit() => Process.WaitForExit();
+
+    public bool WaitForExit(int timeout)
+    {
+        bool exited = Process.WaitForExit(timeout);
+        if (exited)
+        {
+            // To ensure that asynchronous event handling has been completed, call the WaitForExit() overload that takes no parameter after receiving a true from this overload.
+            // From https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?redirectedfrom=MSDN&view=netcore-3.1#System_Diagnostics_Process_WaitForExit_System_Int32_
+            // See also https://github.com/dotnet/runtime/issues/27128
+            Process.WaitForExit();
         }
+        return exited;
+    }
+
+    public void Dispose()
+    {
+        Process.Exited -= ProcessExited;
+        Process.Close();
     }
 }

--- a/src/Buildalyzer/GuidUtility.cs
+++ b/src/Buildalyzer/GuidUtility.cs
@@ -1,113 +1,111 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+/// <summary>
+/// Helper methods for working with <see cref="Guid"/>.
+/// </summary>
+/// <remarks>
+/// From https://github.com/LogosBible/Logos.Utility/blob/master/src/Logos.Utility/GuidUtility.cs.
+/// See also https://stackoverflow.com/a/5657517/807064.
+/// </remarks>
+internal static class GuidUtility
 {
     /// <summary>
-    /// Helper methods for working with <see cref="Guid"/>.
+    /// Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
     /// </summary>
-    /// <remarks>
-    /// From https://github.com/LogosBible/Logos.Utility/blob/master/src/Logos.Utility/GuidUtility.cs.
-    /// See also https://stackoverflow.com/a/5657517/807064.
-    /// </remarks>
-    internal static class GuidUtility
+    /// <param name="namespaceId">The ID of the namespace.</param>
+    /// <param name="name">The name (within that namespace).</param>
+    /// <returns>A UUID derived from the namespace and name.</returns>
+    /// <remarks>See <a href="http://code.logos.com/blog/2011/04/generating_a_deterministic_guid.html">Generating a deterministic GUID</a>.</remarks>
+    public static Guid Create(Guid namespaceId, string name)
     {
-        /// <summary>
-        /// Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
-        /// </summary>
-        /// <param name="namespaceId">The ID of the namespace.</param>
-        /// <param name="name">The name (within that namespace).</param>
-        /// <returns>A UUID derived from the namespace and name.</returns>
-        /// <remarks>See <a href="http://code.logos.com/blog/2011/04/generating_a_deterministic_guid.html">Generating a deterministic GUID</a>.</remarks>
-        public static Guid Create(Guid namespaceId, string name)
+        return Create(namespaceId, name, 5);
+    }
+
+    /// <summary>
+    /// Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
+    /// </summary>
+    /// <param name="namespaceId">The ID of the namespace.</param>
+    /// <param name="name">The name (within that namespace).</param>
+    /// <param name="version">The version number of the UUID to create; this value must be either
+    /// 3 (for MD5 hashing) or 5 (for SHA-1 hashing).</param>
+    /// <returns>A UUID derived from the namespace and name.</returns>
+    /// <remarks>See <a href="http://code.logos.com/blog/2011/04/generating_a_deterministic_guid.html">Generating a deterministic GUID</a>.</remarks>
+    public static Guid Create(Guid namespaceId, string name, int version)
+    {
+        if (name == null)
         {
-            return Create(namespaceId, name, 5);
+            throw new ArgumentNullException(nameof(name));
         }
 
-        /// <summary>
-        /// Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
-        /// </summary>
-        /// <param name="namespaceId">The ID of the namespace.</param>
-        /// <param name="name">The name (within that namespace).</param>
-        /// <param name="version">The version number of the UUID to create; this value must be either
-        /// 3 (for MD5 hashing) or 5 (for SHA-1 hashing).</param>
-        /// <returns>A UUID derived from the namespace and name.</returns>
-        /// <remarks>See <a href="http://code.logos.com/blog/2011/04/generating_a_deterministic_guid.html">Generating a deterministic GUID</a>.</remarks>
-        public static Guid Create(Guid namespaceId, string name, int version)
+        if (version != 3 && version != 5)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (version != 3 && version != 5)
-            {
-                throw new ArgumentOutOfRangeException(nameof(version), "version must be either 3 or 5.");
-            }
-
-            // convert the name to a sequence of octets (as defined by the standard or conventions of its namespace) (step 3)
-            // ASSUME: UTF-8 encoding is always appropriate
-            byte[] nameBytes = Encoding.UTF8.GetBytes(name);
-
-            // convert the namespace UUID to network order (step 3)
-            byte[] namespaceBytes = namespaceId.ToByteArray();
-            SwapByteOrder(namespaceBytes);
-
-            // comput the hash of the name space ID concatenated with the name (step 4)
-            byte[] hash;
-            using (HashAlgorithm algorithm = version == 3 ? (HashAlgorithm)MD5.Create() : SHA1.Create())
-            {
-                algorithm.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
-                algorithm.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
-                hash = algorithm.Hash;
-            }
-
-            // most bytes from the hash are copied straight to the bytes of the new GUID (steps 5-7, 9, 11-12)
-            byte[] newGuid = new byte[16];
-            Array.Copy(hash, 0, newGuid, 0, 16);
-
-            // set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the appropriate 4-bit version number from Section 4.1.3 (step 8)
-            newGuid[6] = (byte)((newGuid[6] & 0x0F) | (version << 4));
-
-            // set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively (step 10)
-            newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
-
-            // convert the resulting UUID to local byte order (step 13)
-            SwapByteOrder(newGuid);
-            return new Guid(newGuid);
+            throw new ArgumentOutOfRangeException(nameof(version), "version must be either 3 or 5.");
         }
 
-        /// <summary>
-        /// The namespace for fully-qualified domain names (from RFC 4122, Appendix C).
-        /// </summary>
-        public static readonly Guid DnsNamespace = new Guid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+        // convert the name to a sequence of octets (as defined by the standard or conventions of its namespace) (step 3)
+        // ASSUME: UTF-8 encoding is always appropriate
+        byte[] nameBytes = Encoding.UTF8.GetBytes(name);
 
-        /// <summary>
-        /// The namespace for URLs (from RFC 4122, Appendix C).
-        /// </summary>
-        public static readonly Guid UrlNamespace = new Guid("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+        // convert the namespace UUID to network order (step 3)
+        byte[] namespaceBytes = namespaceId.ToByteArray();
+        SwapByteOrder(namespaceBytes);
 
-        /// <summary>
-        /// The namespace for ISO OIDs (from RFC 4122, Appendix C).
-        /// </summary>
-        public static readonly Guid IsoOidNamespace = new Guid("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
-
-        // Converts a GUID (expressed as a byte array) to/from network order (MSB-first).
-        internal static void SwapByteOrder(byte[] guid)
+        // comput the hash of the name space ID concatenated with the name (step 4)
+        byte[] hash;
+        using (HashAlgorithm algorithm = version == 3 ? (HashAlgorithm)MD5.Create() : SHA1.Create())
         {
-            SwapBytes(guid, 0, 3);
-            SwapBytes(guid, 1, 2);
-            SwapBytes(guid, 4, 5);
-            SwapBytes(guid, 6, 7);
+            algorithm.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
+            algorithm.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
+            hash = algorithm.Hash;
         }
 
-        private static void SwapBytes(byte[] guid, int left, int right)
-        {
-            byte temp = guid[left];
-            guid[left] = guid[right];
-            guid[right] = temp;
-        }
+        // most bytes from the hash are copied straight to the bytes of the new GUID (steps 5-7, 9, 11-12)
+        byte[] newGuid = new byte[16];
+        Array.Copy(hash, 0, newGuid, 0, 16);
+
+        // set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the appropriate 4-bit version number from Section 4.1.3 (step 8)
+        newGuid[6] = (byte)((newGuid[6] & 0x0F) | (version << 4));
+
+        // set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively (step 10)
+        newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
+
+        // convert the resulting UUID to local byte order (step 13)
+        SwapByteOrder(newGuid);
+        return new Guid(newGuid);
+    }
+
+    /// <summary>
+    /// The namespace for fully-qualified domain names (from RFC 4122, Appendix C).
+    /// </summary>
+    public static readonly Guid DnsNamespace = new Guid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// The namespace for URLs (from RFC 4122, Appendix C).
+    /// </summary>
+    public static readonly Guid UrlNamespace = new Guid("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+
+    /// <summary>
+    /// The namespace for ISO OIDs (from RFC 4122, Appendix C).
+    /// </summary>
+    public static readonly Guid IsoOidNamespace = new Guid("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+
+    // Converts a GUID (expressed as a byte array) to/from network order (MSB-first).
+    internal static void SwapByteOrder(byte[] guid)
+    {
+        SwapBytes(guid, 0, 3);
+        SwapBytes(guid, 1, 2);
+        SwapBytes(guid, 4, 5);
+        SwapBytes(guid, 6, 7);
+    }
+
+    private static void SwapBytes(byte[] guid, int left, int right)
+    {
+        byte temp = guid[left];
+        guid[left] = guid[right];
+        guid[right] = temp;
     }
 }

--- a/src/Buildalyzer/IAnalyzerManager.cs
+++ b/src/Buildalyzer/IAnalyzerManager.cs
@@ -2,32 +2,31 @@
 using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public interface IAnalyzerManager
 {
-    public interface IAnalyzerManager
-    {
-        ILoggerFactory LoggerFactory { get; set; }
+    ILoggerFactory LoggerFactory { get; set; }
 
-        IReadOnlyDictionary<string, IProjectAnalyzer> Projects { get; }
+    IReadOnlyDictionary<string, IProjectAnalyzer> Projects { get; }
 
-        SolutionFile SolutionFile { get; }
+    SolutionFile SolutionFile { get; }
 
-        string SolutionFilePath { get; }
+    string SolutionFilePath { get; }
 
-        /// <summary>
-        /// Analyzes an MSBuild binary log file.
-        /// </summary>
-        /// <param name="binLogPath">The path to the binary log file.</param>
-        /// <param name="buildLoggers">MSBuild loggers to replay events from the log to.</param>
-        /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
-        IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null);
+    /// <summary>
+    /// Analyzes an MSBuild binary log file.
+    /// </summary>
+    /// <param name="binLogPath">The path to the binary log file.</param>
+    /// <param name="buildLoggers">MSBuild loggers to replay events from the log to.</param>
+    /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
+    IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null);
 
-        IProjectAnalyzer GetProject(string projectFilePath);
+    IProjectAnalyzer GetProject(string projectFilePath);
 
-        void RemoveGlobalProperty(string key);
+    void RemoveGlobalProperty(string key);
 
-        void SetEnvironmentVariable(string key, string value);
+    void SetEnvironmentVariable(string key, string value);
 
-        void SetGlobalProperty(string key, string value);
-    }
+    void SetGlobalProperty(string key, string value);
 }

--- a/src/Buildalyzer/IAnalyzerResult.cs
+++ b/src/Buildalyzer/IAnalyzerResult.cs
@@ -1,80 +1,79 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public interface IAnalyzerResult
 {
-    public interface IAnalyzerResult
-    {
-        /// <summary>
-        /// Gets the <see cref="ProjectAnalyzer"/> that generated this result
-        /// or <c>null</c> if the result came from a binary log file.
-        /// </summary>
-        ProjectAnalyzer Analyzer { get; }
+    /// <summary>
+    /// Gets the <see cref="ProjectAnalyzer"/> that generated this result
+    /// or <c>null</c> if the result came from a binary log file.
+    /// </summary>
+    ProjectAnalyzer Analyzer { get; }
 
-        IReadOnlyDictionary<string, IProjectItem[]> Items { get; }
+    IReadOnlyDictionary<string, IProjectItem[]> Items { get; }
 
-        AnalyzerManager Manager { get; }
+    AnalyzerManager Manager { get; }
 
-        /// <summary>
-        /// Contains the <c>PackageReference</c> items for the project.
-        /// The key is a package ID and the value is a <see cref="IReadOnlyDictionary{TKey, TValue}"/>
-        /// that includes all the package reference metadata, typically including a "Version" key.
-        /// </summary>
-        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences { get; }
+    /// <summary>
+    /// Contains the <c>PackageReference</c> items for the project.
+    /// The key is a package ID and the value is a <see cref="IReadOnlyDictionary{TKey, TValue}"/>
+    /// that includes all the package reference metadata, typically including a "Version" key.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences { get; }
 
-        /// <summary>
-        /// The full normalized path to the project file.
-        /// </summary>
-        string ProjectFilePath { get; }
+    /// <summary>
+    /// The full normalized path to the project file.
+    /// </summary>
+    string ProjectFilePath { get; }
 
-        /// <summary>
-        /// Gets a GUID for the project. This first attempts to get the <c>ProjectGuid</c>
-        /// MSBuild property. If that's not available, checks for a GUID from the
-        /// solution (if originally provided). If neither of those are available, it
-        /// will generate a UUID GUID by hashing the project path relative to the solution path (so it's repeatable).
-        /// </summary>
-        Guid ProjectGuid { get; }
+    /// <summary>
+    /// Gets a GUID for the project. This first attempts to get the <c>ProjectGuid</c>
+    /// MSBuild property. If that's not available, checks for a GUID from the
+    /// solution (if originally provided). If neither of those are available, it
+    /// will generate a UUID GUID by hashing the project path relative to the solution path (so it's repeatable).
+    /// </summary>
+    Guid ProjectGuid { get; }
 
-        IEnumerable<string> ProjectReferences { get; }
+    IEnumerable<string> ProjectReferences { get; }
 
-        IReadOnlyDictionary<string, string> Properties { get; }
+    IReadOnlyDictionary<string, string> Properties { get; }
 
-        string[] References { get; }
+    string[] References { get; }
 
-        string[] AnalyzerReferences { get; }
+    string[] AnalyzerReferences { get; }
 
-        string[] SourceFiles { get; }
+    string[] SourceFiles { get; }
 
-        bool Succeeded { get; }
+    bool Succeeded { get; }
 
-        string TargetFramework { get; }
+    string TargetFramework { get; }
 
-        string[] PreprocessorSymbols { get; }
+    string[] PreprocessorSymbols { get; }
 
-        string[] AdditionalFiles { get; }
+    string[] AdditionalFiles { get; }
 
-        /// <summary>
-        /// Gets the compiler command produced by the CoreCompile task.
-        /// This is <see cref="CompilerFilePath"/> + <see cref="CompilerArguments"/>.
-        /// </summary>
-        string Command { get; }
+    /// <summary>
+    /// Gets the compiler command produced by the CoreCompile task.
+    /// This is <see cref="CompilerFilePath"/> + <see cref="CompilerArguments"/>.
+    /// </summary>
+    string Command { get; }
 
-        /// <summary>
-        /// Gets the path of the compiler command produced by the CoreCompile task.
-        /// </summary>
-        string CompilerFilePath { get; }
+    /// <summary>
+    /// Gets the path of the compiler command produced by the CoreCompile task.
+    /// </summary>
+    string CompilerFilePath { get; }
 
-        /// <summary>
-        /// Gets the arguments passed to the compiler produced by the CoreCompile task.
-        /// </summary>
-        string[] CompilerArguments { get; }
+    /// <summary>
+    /// Gets the arguments passed to the compiler produced by the CoreCompile task.
+    /// </summary>
+    string[] CompilerArguments { get; }
 
-        /// <summary>
-        /// Gets the value of the specified property and returns <c>null</c>
-        /// if the property could not be found.
-        /// </summary>
-        /// <param name="name">The name of the property.</param>
-        /// <returns>The value of the property or <c>null</c>.</returns>
-        string GetProperty(string name);
-    }
+    /// <summary>
+    /// Gets the value of the specified property and returns <c>null</c>
+    /// if the property could not be found.
+    /// </summary>
+    /// <param name="name">The name of the property.</param>
+    /// <returns>The value of the property or <c>null</c>.</returns>
+    string GetProperty(string name);
 }

--- a/src/Buildalyzer/IAnalyzerResults.cs
+++ b/src/Buildalyzer/IAnalyzerResults.cs
@@ -1,21 +1,20 @@
 ﻿using System.Collections.Generic;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public interface IAnalyzerResults : IEnumerable<IAnalyzerResult>
 {
-    public interface IAnalyzerResults : IEnumerable<IAnalyzerResult>
-    {
-        IAnalyzerResult this[string targetFramework] { get; }
+    IAnalyzerResult this[string targetFramework] { get; }
 
-        int Count { get; }
+    int Count { get; }
 
-        bool OverallSuccess { get; }
+    bool OverallSuccess { get; }
 
-        IEnumerable<IAnalyzerResult> Results { get; }
+    IEnumerable<IAnalyzerResult> Results { get; }
 
-        IEnumerable<string> TargetFrameworks { get; }
+    IEnumerable<string> TargetFrameworks { get; }
 
-        bool ContainsTargetFramework(string targetFramework);
+    bool ContainsTargetFramework(string targetFramework);
 
-        bool TryGetTargetFramework(string targetFramework, out IAnalyzerResult result);
-    }
+    bool TryGetTargetFramework(string targetFramework, out IAnalyzerResult result);
 }

--- a/src/Buildalyzer/IEnumerableExtensions.cs
+++ b/src/Buildalyzer/IEnumerableExtensions.cs
@@ -3,28 +3,27 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+internal static class IEnumerableExtensions
 {
-    internal static class IEnumerableExtensions
-    {
-        internal static IEnumerable<DictionaryEntry> ToDictionaryEntries(this IEnumerable enumerable) =>
-            enumerable
-                .Cast<object>()
-                .Select(x =>
+    internal static IEnumerable<DictionaryEntry> ToDictionaryEntries(this IEnumerable enumerable) =>
+        enumerable
+            .Cast<object>()
+            .Select(x =>
+            {
+                switch (x)
                 {
-                    switch (x)
-                    {
-                        case DictionaryEntry dictionaryEntry:
-                            return dictionaryEntry;
-                        case KeyValuePair<string, string> kvpStringString:
-                            return new DictionaryEntry(kvpStringString.Key, kvpStringString.Value);
-                        case KeyValuePair<string, object> kvpStringObject:
-                            return new DictionaryEntry(kvpStringObject.Key, kvpStringObject.Value);
-                        case KeyValuePair<object, object> kvpObjectObject:
-                            return new DictionaryEntry(kvpObjectObject.Key, kvpObjectObject.Value);
-                        default:
-                            throw new InvalidOperationException("Could not determine enumerable dictionary entry type");
-                    }
-                });
-    }
+                    case DictionaryEntry dictionaryEntry:
+                        return dictionaryEntry;
+                    case KeyValuePair<string, string> kvpStringString:
+                        return new DictionaryEntry(kvpStringString.Key, kvpStringString.Value);
+                    case KeyValuePair<string, object> kvpStringObject:
+                        return new DictionaryEntry(kvpStringObject.Key, kvpStringObject.Value);
+                    case KeyValuePair<object, object> kvpObjectObject:
+                        return new DictionaryEntry(kvpObjectObject.Key, kvpObjectObject.Value);
+                    default:
+                        throw new InvalidOperationException("Could not determine enumerable dictionary entry type");
+                }
+            });
 }

--- a/src/Buildalyzer/IProjectAnalyzer.cs
+++ b/src/Buildalyzer/IProjectAnalyzer.cs
@@ -6,148 +6,147 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Logging;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public interface IProjectAnalyzer
 {
-    public interface IProjectAnalyzer
-    {
-        IEnumerable<Microsoft.Build.Framework.ILogger> BuildLoggers { get; }
+    IEnumerable<Microsoft.Build.Framework.ILogger> BuildLoggers { get; }
 
-        EnvironmentFactory EnvironmentFactory { get; }
+    EnvironmentFactory EnvironmentFactory { get; }
 
-        /// <summary>
-        /// The environment variables for MSBuild to be used for every build from this analyzer.
-        /// </summary>
-        /// <remarks>
-        /// Additional environment variables may be added or changed by individual build environment.
-        /// </remarks>
-        IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+    /// <summary>
+    /// The environment variables for MSBuild to be used for every build from this analyzer.
+    /// </summary>
+    /// <remarks>
+    /// Additional environment variables may be added or changed by individual build environment.
+    /// </remarks>
+    IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
 
-        /// <summary>
-        /// The global properties for MSBuild to be used for every build from this analyzer.
-        /// </summary>
-        /// <remarks>
-        /// Additional global properties may be added or changed by individual build environment.
-        /// </remarks>
-        IReadOnlyDictionary<string, string> GlobalProperties { get; }
+    /// <summary>
+    /// The global properties for MSBuild to be used for every build from this analyzer.
+    /// </summary>
+    /// <remarks>
+    /// Additional global properties may be added or changed by individual build environment.
+    /// </remarks>
+    IReadOnlyDictionary<string, string> GlobalProperties { get; }
 
-        /// <summary>
-        /// Controls whether empty, invalid, and missing targets should be ignored during project load.
-        /// </summary>
-        bool IgnoreFaultyImports { get; set; }
+    /// <summary>
+    /// Controls whether empty, invalid, and missing targets should be ignored during project load.
+    /// </summary>
+    bool IgnoreFaultyImports { get; set; }
 
-        ILogger<ProjectAnalyzer> Logger { get; set; }
+    ILogger<ProjectAnalyzer> Logger { get; set; }
 
-        AnalyzerManager Manager { get; }
+    AnalyzerManager Manager { get; }
 
-        IProjectFile ProjectFile { get; }
+    IProjectFile ProjectFile { get; }
 
-        /// <summary>
-        /// Gets a GUID for the project. This checks for a GUID from the
-        /// solution (if originally provided). If this isn't available, it
-        /// will generate a UUID GUID by hashing the project path relative to the solution path (so it's repeatable).
-        /// </summary>
-        Guid ProjectGuid { get; }
+    /// <summary>
+    /// Gets a GUID for the project. This checks for a GUID from the
+    /// solution (if originally provided). If this isn't available, it
+    /// will generate a UUID GUID by hashing the project path relative to the solution path (so it's repeatable).
+    /// </summary>
+    Guid ProjectGuid { get; }
 
-        ProjectInSolution ProjectInSolution { get; }
+    ProjectInSolution ProjectInSolution { get; }
 
-        string SolutionDirectory { get; }
+    string SolutionDirectory { get; }
 
-        /// <summary>
-        /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
-        /// </summary>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build();
+    /// <summary>
+    /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
+    /// </summary>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build();
 
-        /// <summary>
-        /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
-        /// </summary>
-        /// <param name="buildEnvironment">The build environment to use for the build.</param>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build(BuildEnvironment buildEnvironment);
+    /// <summary>
+    /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
+    /// </summary>
+    /// <param name="buildEnvironment">The build environment to use for the build.</param>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build(BuildEnvironment buildEnvironment);
 
-        /// <summary>
-        /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
-        /// </summary>
-        /// <param name="environmentOptions">The environment options to use for the build.</param>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build(EnvironmentOptions environmentOptions);
+    /// <summary>
+    /// Builds the project without specifying a target framework. In a multi-targeted project this will return a <see cref="AnalyzerResult"/> for each target framework.
+    /// </summary>
+    /// <param name="environmentOptions">The environment options to use for the build.</param>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build(EnvironmentOptions environmentOptions);
 
-        /// <summary>
-        /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFramework">The target framework to build.</param>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build(string targetFramework);
+    /// <summary>
+    /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFramework">The target framework to build.</param>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build(string targetFramework);
 
-        /// <summary>
-        /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFramework">The target framework to build.</param>
-        /// <param name="buildEnvironment">The build environment to use for the build.</param>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment);
+    /// <summary>
+    /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFramework">The target framework to build.</param>
+    /// <param name="buildEnvironment">The build environment to use for the build.</param>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment);
 
-        /// <summary>
-        /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFramework">The target framework to build.</param>
-        /// <param name="environmentOptions">The environment options to use for the build.</param>
-        /// <returns>The result of the build process.</returns>
-        IAnalyzerResults Build(string targetFramework, EnvironmentOptions environmentOptions);
+    /// <summary>
+    /// Builds a specific target framework. In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFramework">The target framework to build.</param>
+    /// <param name="environmentOptions">The environment options to use for the build.</param>
+    /// <returns>The result of the build process.</returns>
+    IAnalyzerResults Build(string targetFramework, EnvironmentOptions environmentOptions);
 
-        /// <summary>
-        /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFrameworks">The set of target frameworks to build.</param>
-        /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
-        IAnalyzerResults Build(string[] targetFrameworks);
+    /// <summary>
+    /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFrameworks">The set of target frameworks to build.</param>
+    /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
+    IAnalyzerResults Build(string[] targetFrameworks);
 
-        /// <summary>
-        /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFrameworks">The set of target frameworks to build.</param>
-        /// <param name="buildEnvironment">The build environment to use for the build.</param>
-        /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
-        IAnalyzerResults Build(string[] targetFrameworks, BuildEnvironment buildEnvironment);
+    /// <summary>
+    /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFrameworks">The set of target frameworks to build.</param>
+    /// <param name="buildEnvironment">The build environment to use for the build.</param>
+    /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
+    IAnalyzerResults Build(string[] targetFrameworks, BuildEnvironment buildEnvironment);
 
-        /// <summary>
-        /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
-        /// but the target framework(s) not specified may be empty.
-        /// </summary>
-        /// <param name="targetFrameworks">The set of target frameworks to build.</param>
-        /// <param name="environmentOptions">The environment options to use for the build.</param>
-        /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
-        IAnalyzerResults Build(string[] targetFrameworks, EnvironmentOptions environmentOptions);
+    /// <summary>
+    /// Builds the requested target framework(s). In a multi-targeted project this will still return a <see cref="AnalyzerResult"/> for each target framework,
+    /// but the target framework(s) not specified may be empty.
+    /// </summary>
+    /// <param name="targetFrameworks">The set of target frameworks to build.</param>
+    /// <param name="environmentOptions">The environment options to use for the build.</param>
+    /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
+    IAnalyzerResults Build(string[] targetFrameworks, EnvironmentOptions environmentOptions);
 
-        void AddBinaryLogger(
-            string binaryLogFilePath = null,
-            BinaryLogger.ProjectImportsCollectionMode collectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed);
+    void AddBinaryLogger(
+        string binaryLogFilePath = null,
+        BinaryLogger.ProjectImportsCollectionMode collectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed);
 
-        /// <summary>
-        /// Adds an MSBuild logger to the build. Note that this may have a large penalty on build performance.
-        /// </summary>
-        /// <remarks>
-        /// Normally, the minimum required amount of log events are forwarded from the MSBuild process to Buildalyzer.
-        /// By attaching arbitrary loggers, MSBuild must forward every log event so the logger has a chance to handle it.
-        /// </remarks>
-        /// <param name="logger">The logger to add.</param>
-        void AddBuildLogger(Microsoft.Build.Framework.ILogger logger);
+    /// <summary>
+    /// Adds an MSBuild logger to the build. Note that this may have a large penalty on build performance.
+    /// </summary>
+    /// <remarks>
+    /// Normally, the minimum required amount of log events are forwarded from the MSBuild process to Buildalyzer.
+    /// By attaching arbitrary loggers, MSBuild must forward every log event so the logger has a chance to handle it.
+    /// </remarks>
+    /// <param name="logger">The logger to add.</param>
+    void AddBuildLogger(Microsoft.Build.Framework.ILogger logger);
 
-        /// <summary>
-        /// Removes an MSBuild logger from the build.
-        /// </summary>
-        /// <param name="logger">The logger to remove.</param>
-        void RemoveBuildLogger(Microsoft.Build.Framework.ILogger logger);
+    /// <summary>
+    /// Removes an MSBuild logger from the build.
+    /// </summary>
+    /// <param name="logger">The logger to remove.</param>
+    void RemoveBuildLogger(Microsoft.Build.Framework.ILogger logger);
 
-        void RemoveGlobalProperty(string key);
+    void RemoveGlobalProperty(string key);
 
-        void SetEnvironmentVariable(string key, string value);
+    void SetEnvironmentVariable(string key, string value);
 
-        void SetGlobalProperty(string key, string value);
-    }
+    void SetGlobalProperty(string key, string value);
 }

--- a/src/Buildalyzer/IProjectItem.cs
+++ b/src/Buildalyzer/IProjectItem.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public interface IProjectItem
 {
-    public interface IProjectItem
-    {
-        string ItemSpec { get; }
-        IReadOnlyDictionary<string, string> Metadata { get; }
-    }
+    string ItemSpec { get; }
+    IReadOnlyDictionary<string, string> Metadata { get; }
 }

--- a/src/Buildalyzer/InterlockedBool.cs
+++ b/src/Buildalyzer/InterlockedBool.cs
@@ -1,44 +1,40 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+internal class InterlockedBool
 {
-    internal class InterlockedBool
+    private volatile int _set;
+
+    public InterlockedBool()
     {
-        private volatile int _set;
+        _set = 0;
+    }
 
-        public InterlockedBool()
-        {
-            _set = 0;
-        }
+    public InterlockedBool(bool initialState)
+    {
+        _set = initialState ? 1 : 0;
+    }
 
-        public InterlockedBool(bool initialState)
-        {
-            _set = initialState ? 1 : 0;
-        }
-
-        // Returns the previous switch state of the switch
-        public bool Set()
-        {
+    // Returns the previous switch state of the switch
+    public bool Set()
+    {
 #pragma warning disable 420
-            return Interlocked.Exchange(ref _set, 1) != 0;
+        return Interlocked.Exchange(ref _set, 1) != 0;
 #pragma warning restore 420
-        }
+    }
 
-        // Returns the previous switch state of the switch
-        public bool Unset()
-        {
+    // Returns the previous switch state of the switch
+    public bool Unset()
+    {
 #pragma warning disable 420
-            return Interlocked.Exchange(ref _set, 0) != 0;
+        return Interlocked.Exchange(ref _set, 0) != 0;
 #pragma warning restore 420
-        }
+    }
 
-        // Returns the current state
-        public static implicit operator bool(InterlockedBool interlockedBool)
-        {
-            return interlockedBool._set != 0;
-        }
+    // Returns the current state
+    public static implicit operator bool(InterlockedBool interlockedBool)
+    {
+        return interlockedBool._set != 0;
     }
 }

--- a/src/Buildalyzer/Logging/BuildEventArgsReaderProxy.cs
+++ b/src/Buildalyzer/Logging/BuildEventArgsReaderProxy.cs
@@ -1,36 +1,33 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 
-namespace Buildalyzer.Logging
+namespace Buildalyzer.Logging;
+
+internal class BuildEventArgsReaderProxy
 {
-    internal class BuildEventArgsReaderProxy
+    private readonly Func<BuildEventArgs> _read;
+
+    public BuildEventArgsReaderProxy(BinaryReader reader)
     {
-        private readonly Func<BuildEventArgs> _read;
-
-        public BuildEventArgsReaderProxy(BinaryReader reader)
+        // Use reflection to get the Microsoft.Build.Logging.BuildEventArgsReader.Read() method
+        object argsReader;
+        Type buildEventArgsReader = typeof(BinaryLogger).GetTypeInfo().Assembly.GetType("Microsoft.Build.Logging.BuildEventArgsReader");
+        ConstructorInfo readerCtor = buildEventArgsReader.GetConstructor(new[] { typeof(BinaryReader) });
+        if (readerCtor != null)
         {
-            // Use reflection to get the Microsoft.Build.Logging.BuildEventArgsReader.Read() method
-            object argsReader;
-            Type buildEventArgsReader = typeof(BinaryLogger).GetTypeInfo().Assembly.GetType("Microsoft.Build.Logging.BuildEventArgsReader");
-            ConstructorInfo readerCtor = buildEventArgsReader.GetConstructor(new[] { typeof(BinaryReader) });
-            if (readerCtor != null)
-            {
-                argsReader = readerCtor.Invoke(new[] { reader });
-            }
-            else
-            {
-                readerCtor = buildEventArgsReader.GetConstructor(new[] { typeof(BinaryReader), typeof(int) });
-                argsReader = readerCtor.Invoke(new object[] { reader, 7 });
-            }
-            MethodInfo readMethod = buildEventArgsReader.GetMethod("Read");
-            _read = (Func<BuildEventArgs>)readMethod.CreateDelegate(typeof(Func<BuildEventArgs>), argsReader);
+            argsReader = readerCtor.Invoke(new[] { reader });
         }
-
-        public BuildEventArgs Read() => _read();
+        else
+        {
+            readerCtor = buildEventArgsReader.GetConstructor(new[] { typeof(BinaryReader), typeof(int) });
+            argsReader = readerCtor.Invoke(new object[] { reader, 7 });
+        }
+        MethodInfo readMethod = buildEventArgsReader.GetMethod("Read");
+        _read = (Func<BuildEventArgs>)readMethod.CreateDelegate(typeof(Func<BuildEventArgs>), argsReader);
     }
+
+    public BuildEventArgs Read() => _read();
 }

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -6,206 +6,205 @@ using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Logging
+namespace Buildalyzer.Logging;
+
+internal class EventProcessor : IDisposable
 {
-    internal class EventProcessor : IDisposable
+    private readonly Dictionary<string, AnalyzerResult> _results = new Dictionary<string, AnalyzerResult>();
+    private readonly Stack<AnalyzerResult> _currentResult = new Stack<AnalyzerResult>();
+    private readonly Stack<TargetStartedEventArgs> _targetStack = new Stack<TargetStartedEventArgs>();
+    private readonly Dictionary<int, PropertiesAndItems> _evalulationResults = new Dictionary<int, PropertiesAndItems>();
+    private readonly AnalyzerManager _manager;
+    private readonly ProjectAnalyzer _analyzer;
+    private readonly ILogger<EventProcessor> _logger;
+    private readonly IEnumerable<Microsoft.Build.Framework.ILogger> _buildLoggers;
+    private readonly IEventSource _eventSource;
+    private readonly bool _analyze;
+
+    private string _projectFilePath;
+
+    public bool OverallSuccess { get; private set; }
+
+    public IEnumerable<AnalyzerResult> Results => _results.Values;
+
+    public EventProcessor(AnalyzerManager manager, ProjectAnalyzer analyzer, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers, IEventSource eventSource, bool analyze)
     {
-        private readonly Dictionary<string, AnalyzerResult> _results = new Dictionary<string, AnalyzerResult>();
-        private readonly Stack<AnalyzerResult> _currentResult = new Stack<AnalyzerResult>();
-        private readonly Stack<TargetStartedEventArgs> _targetStack = new Stack<TargetStartedEventArgs>();
-        private readonly Dictionary<int, PropertiesAndItems> _evalulationResults = new Dictionary<int, PropertiesAndItems>();
-        private readonly AnalyzerManager _manager;
-        private readonly ProjectAnalyzer _analyzer;
-        private readonly ILogger<EventProcessor> _logger;
-        private readonly IEnumerable<Microsoft.Build.Framework.ILogger> _buildLoggers;
-        private readonly IEventSource _eventSource;
-        private readonly bool _analyze;
+        _manager = manager;
+        _analyzer = analyzer;
+        _logger = manager.LoggerFactory?.CreateLogger<EventProcessor>();
+        _buildLoggers = buildLoggers ?? Array.Empty<Microsoft.Build.Framework.ILogger>();
+        _eventSource = eventSource;
+        _analyze = analyze;
 
-        private string _projectFilePath;
+        _projectFilePath = _analyzer?.ProjectFile.Path;
 
-        public bool OverallSuccess { get; private set; }
-
-        public IEnumerable<AnalyzerResult> Results => _results.Values;
-
-        public EventProcessor(AnalyzerManager manager, ProjectAnalyzer analyzer, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers, IEventSource eventSource, bool analyze)
+        // Initialize the loggers
+        foreach (Microsoft.Build.Framework.ILogger buildLogger in _buildLoggers)
         {
-            _manager = manager;
-            _analyzer = analyzer;
-            _logger = manager.LoggerFactory?.CreateLogger<EventProcessor>();
-            _buildLoggers = buildLoggers ?? Array.Empty<Microsoft.Build.Framework.ILogger>();
-            _eventSource = eventSource;
-            _analyze = analyze;
-
-            _projectFilePath = _analyzer?.ProjectFile.Path;
-
-            // Initialize the loggers
-            foreach (Microsoft.Build.Framework.ILogger buildLogger in _buildLoggers)
-            {
-                buildLogger.Initialize(eventSource);
-            }
-
-            // Send events to the tree constructor
-            if (analyze)
-            {
-                eventSource.StatusEventRaised += StatusEventRaised;
-                eventSource.ProjectStarted += ProjectStarted;
-                eventSource.ProjectFinished += ProjectFinished;
-                eventSource.TargetStarted += TargetStarted;
-                eventSource.TargetFinished += TargetFinished;
-                eventSource.MessageRaised += MessageRaised;
-                eventSource.BuildFinished += BuildFinished;
-                if (_logger != null)
-                {
-                    eventSource.ErrorRaised += ErrorRaised;
-                }
-            }
+            buildLogger.Initialize(eventSource);
         }
 
-        // In binlog 14 we need to gather properties and items during evaluation and "glue" them with the project event args
-        // But can never remove ProjectStarted: "even v14 will log them on ProjectStarted if any legacy loggers are present (for compat)"
-        // See https://twitter.com/KirillOsenkov/status/1427686459713019904
-        private void StatusEventRaised(object sender, BuildStatusEventArgs e)
+        // Send events to the tree constructor
+        if (analyze)
         {
-            if (e is ProjectEvaluationFinishedEventArgs slEv)
+            eventSource.StatusEventRaised += StatusEventRaised;
+            eventSource.ProjectStarted += ProjectStarted;
+            eventSource.ProjectFinished += ProjectFinished;
+            eventSource.TargetStarted += TargetStarted;
+            eventSource.TargetFinished += TargetFinished;
+            eventSource.MessageRaised += MessageRaised;
+            eventSource.BuildFinished += BuildFinished;
+            if (_logger != null)
             {
-                _evalulationResults[slEv.BuildEventContext.EvaluationId] = new PropertiesAndItems
+                eventSource.ErrorRaised += ErrorRaised;
+            }
+        }
+    }
+
+    // In binlog 14 we need to gather properties and items during evaluation and "glue" them with the project event args
+    // But can never remove ProjectStarted: "even v14 will log them on ProjectStarted if any legacy loggers are present (for compat)"
+    // See https://twitter.com/KirillOsenkov/status/1427686459713019904
+    private void StatusEventRaised(object sender, BuildStatusEventArgs e)
+    {
+        if (e is ProjectEvaluationFinishedEventArgs slEv)
+        {
+            _evalulationResults[slEv.BuildEventContext.EvaluationId] = new PropertiesAndItems
+            {
+                Properties = slEv.Properties,
+                Items = slEv.Items
+            };
+        }
+    }
+
+    private void ProjectStarted(object sender, ProjectStartedEventArgs e)
+    {
+        // If we're not using an analyzer (I.e., from a binary log) and this is the first project file path we've seen, then it's the primary
+        if (_projectFilePath == null)
+        {
+            _projectFilePath = AnalyzerManager.NormalizePath(e.ProjectFile);
+        }
+
+        // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
+        if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
+        {
+            // Get the items and properties from the evaluation if needed
+            PropertiesAndItems propertiesAndItems = e.Properties is null
+                ? (_evalulationResults.TryGetValue(e.BuildEventContext.EvaluationId, out PropertiesAndItems evaluationResult)
+                    ? evaluationResult
+                    : null)
+                : new PropertiesAndItems
                 {
-                    Properties = slEv.Properties,
-                    Items = slEv.Items
+                    Properties = e.Properties,
+                    Items = e.Items
                 };
-            }
-        }
 
-        private void ProjectStarted(object sender, ProjectStartedEventArgs e)
-        {
-            // If we're not using an analyzer (I.e., from a binary log) and this is the first project file path we've seen, then it's the primary
-            if (_projectFilePath == null)
+            // Get the TFM for this project
+            string tfm = propertiesAndItems
+                ?.Properties
+                ?.ToDictionaryEntries()
+                .FirstOrDefault(x => string.Equals(x.Key.ToString(), "TargetFrameworkMoniker", StringComparison.OrdinalIgnoreCase))
+                .Value
+                ?.ToString() ?? string.Empty; // use an empty string if no target framework was found, for example in case of C++ projects with VS >= 2022
+            if (propertiesAndItems != null && propertiesAndItems.Properties != null && propertiesAndItems.Items != null)
             {
-                _projectFilePath = AnalyzerManager.NormalizePath(e.ProjectFile);
-            }
-
-            // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
-            if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
-            {
-                // Get the items and properties from the evaluation if needed
-                PropertiesAndItems propertiesAndItems = e.Properties is null
-                    ? (_evalulationResults.TryGetValue(e.BuildEventContext.EvaluationId, out PropertiesAndItems evaluationResult)
-                        ? evaluationResult
-                        : null)
-                    : new PropertiesAndItems
-                    {
-                        Properties = e.Properties,
-                        Items = e.Items
-                    };
-
-                // Get the TFM for this project
-                string tfm = propertiesAndItems
-                    ?.Properties
-                    ?.ToDictionaryEntries()
-                    .FirstOrDefault(x => string.Equals(x.Key.ToString(), "TargetFrameworkMoniker", StringComparison.OrdinalIgnoreCase))
-                    .Value
-                    ?.ToString() ?? string.Empty; // use an empty string if no target framework was found, for example in case of C++ projects with VS >= 2022
-                if (propertiesAndItems != null && propertiesAndItems.Properties != null && propertiesAndItems.Items != null)
+                if (!_results.TryGetValue(tfm, out AnalyzerResult result))
                 {
-                    if (!_results.TryGetValue(tfm, out AnalyzerResult result))
-                    {
-                        result = new AnalyzerResult(_projectFilePath, _manager, _analyzer);
-                        _results[tfm] = result;
-                    }
-                    result.ProcessProject(propertiesAndItems);
-                    _currentResult.Push(result);
-                    return;
+                    result = new AnalyzerResult(_projectFilePath, _manager, _analyzer);
+                    _results[tfm] = result;
                 }
-
-                // Push a null result so the stack is balanced on project finish
-                _currentResult.Push(null);
+                result.ProcessProject(propertiesAndItems);
+                _currentResult.Push(result);
+                return;
             }
-        }
 
-        private void ProjectFinished(object sender, ProjectFinishedEventArgs e)
+            // Push a null result so the stack is balanced on project finish
+            _currentResult.Push(null);
+        }
+    }
+
+    private void ProjectFinished(object sender, ProjectFinishedEventArgs e)
+    {
+        // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
+        if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
         {
-            // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
-            if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
+            AnalyzerResult result = _currentResult.Pop();
+            if (result != null)
             {
-                AnalyzerResult result = _currentResult.Pop();
-                if (result != null)
-                {
-                    result.Succeeded = e.Succeeded;
-                }
+                result.Succeeded = e.Succeeded;
             }
         }
+    }
 
-        private void TargetStarted(object sender, TargetStartedEventArgs e)
+    private void TargetStarted(object sender, TargetStartedEventArgs e)
+    {
+        _targetStack.Push(e);
+    }
+
+    private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    {
+        if (_targetStack.Pop().TargetName != e.TargetName)
         {
-            _targetStack.Push(e);
+            // Sanity check
+            throw new InvalidOperationException("Mismatched target events");
         }
+    }
 
-        private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    private void MessageRaised(object sender, BuildMessageEventArgs e)
+    {
+        AnalyzerResult result = _currentResult.Count == 0 ? null : _currentResult.Peek();
+        if (result is object)
         {
-            if (_targetStack.Pop().TargetName != e.TargetName)
+            // Process the command line arguments for the Fsc task
+            if (e.SenderName?.Equals("Fsc", StringComparison.OrdinalIgnoreCase) == true
+                && !string.IsNullOrWhiteSpace(e.Message)
+                && _targetStack.Any(x => x.TargetName == "CoreCompile")
+                && !result.HasFscArguments())
             {
-                // Sanity check
-                throw new InvalidOperationException("Mismatched target events");
+                result.ProcessFscCommandLine(e.Message);
+            }
+
+            // Process the command line arguments for the Csc task
+            if (e is TaskCommandLineEventArgs cmd
+                && string.Equals(cmd.TaskName, "Csc", StringComparison.OrdinalIgnoreCase))
+            {
+                result.ProcessCscCommandLine(cmd.CommandLine, _targetStack.Any(x => x.TargetName == "CoreCompile"));
+            }
+
+            if (e is TaskCommandLineEventArgs cmdVbc &&
+                string.Equals(cmdVbc.TaskName, "Vbc", StringComparison.OrdinalIgnoreCase))
+            {
+                result.ProcessVbcCommandLine(cmdVbc.CommandLine);
+            }
+        }
+    }
+
+    private void BuildFinished(object sender, BuildFinishedEventArgs e)
+    {
+        OverallSuccess = e.Succeeded;
+    }
+
+    private void ErrorRaised(object sender, BuildErrorEventArgs e) => _logger.LogError(e.Message);
+
+    public void Dispose()
+    {
+        if (_analyze)
+        {
+            _eventSource.ProjectStarted -= ProjectStarted;
+            _eventSource.ProjectFinished -= ProjectFinished;
+            _eventSource.TargetStarted -= TargetStarted;
+            _eventSource.TargetFinished -= TargetFinished;
+            _eventSource.MessageRaised -= MessageRaised;
+            _eventSource.BuildFinished -= BuildFinished;
+            if (_logger != null)
+            {
+                _eventSource.ErrorRaised -= ErrorRaised;
             }
         }
 
-        private void MessageRaised(object sender, BuildMessageEventArgs e)
+        // Need to release the loggers in case they get used again (I.e., Restore followed by Clean;Build)
+        foreach (Microsoft.Build.Framework.ILogger buildLogger in _buildLoggers)
         {
-            AnalyzerResult result = _currentResult.Count == 0 ? null : _currentResult.Peek();
-            if (result is object)
-            {
-                // Process the command line arguments for the Fsc task
-                if (e.SenderName?.Equals("Fsc", StringComparison.OrdinalIgnoreCase) == true
-                    && !string.IsNullOrWhiteSpace(e.Message)
-                    && _targetStack.Any(x => x.TargetName == "CoreCompile")
-                    && !result.HasFscArguments())
-                {
-                    result.ProcessFscCommandLine(e.Message);
-                }
-
-                // Process the command line arguments for the Csc task
-                if (e is TaskCommandLineEventArgs cmd
-                    && string.Equals(cmd.TaskName, "Csc", StringComparison.OrdinalIgnoreCase))
-                {
-                    result.ProcessCscCommandLine(cmd.CommandLine, _targetStack.Any(x => x.TargetName == "CoreCompile"));
-                }
-
-                if (e is TaskCommandLineEventArgs cmdVbc &&
-                    string.Equals(cmdVbc.TaskName, "Vbc", StringComparison.OrdinalIgnoreCase))
-                {
-                    result.ProcessVbcCommandLine(cmdVbc.CommandLine);
-                }
-            }
-        }
-
-        private void BuildFinished(object sender, BuildFinishedEventArgs e)
-        {
-            OverallSuccess = e.Succeeded;
-        }
-
-        private void ErrorRaised(object sender, BuildErrorEventArgs e) => _logger.LogError(e.Message);
-
-        public void Dispose()
-        {
-            if (_analyze)
-            {
-                _eventSource.ProjectStarted -= ProjectStarted;
-                _eventSource.ProjectFinished -= ProjectFinished;
-                _eventSource.TargetStarted -= TargetStarted;
-                _eventSource.TargetFinished -= TargetFinished;
-                _eventSource.MessageRaised -= MessageRaised;
-                _eventSource.BuildFinished -= BuildFinished;
-                if (_logger != null)
-                {
-                    _eventSource.ErrorRaised -= ErrorRaised;
-                }
-            }
-
-            // Need to release the loggers in case they get used again (I.e., Restore followed by Clean;Build)
-            foreach (Microsoft.Build.Framework.ILogger buildLogger in _buildLoggers)
-            {
-                buildLogger.Shutdown();
-            }
+            buildLogger.Shutdown();
         }
     }
 }

--- a/src/Buildalyzer/Logging/PropertiesAndItems.cs
+++ b/src/Buildalyzer/Logging/PropertiesAndItems.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections;
 
-namespace Buildalyzer.Logging
+namespace Buildalyzer.Logging;
+
+internal class PropertiesAndItems
 {
-    internal class PropertiesAndItems
-    {
-        public IEnumerable Properties { get; set; }
-        public IEnumerable Items { get; set; }
-    }
+    public IEnumerable Properties { get; set; }
+    public IEnumerable Items { get; set; }
 }

--- a/src/Buildalyzer/Logging/TextWriterLogger.cs
+++ b/src/Buildalyzer/Logging/TextWriterLogger.cs
@@ -2,22 +2,21 @@
 using System.IO;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Logging
+namespace Buildalyzer.Logging;
+
+internal class TextWriterLogger : ILogger
 {
-    internal class TextWriterLogger : ILogger
+    private readonly TextWriter _textWriter;
+
+    public TextWriterLogger(TextWriter textWriter)
     {
-        private readonly TextWriter _textWriter;
-
-        public TextWriterLogger(TextWriter textWriter)
-        {
-            _textWriter = textWriter;
-        }
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
-            _textWriter.Write(formatter(state, exception));
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public IDisposable BeginScope<TState>(TState state) => new EmptyDisposable();
+        _textWriter = textWriter;
     }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+        _textWriter.Write(formatter(state, exception));
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable BeginScope<TState>(TState state) => new EmptyDisposable();
 }

--- a/src/Buildalyzer/Logging/TextWriterLoggerProvider.cs
+++ b/src/Buildalyzer/Logging/TextWriterLoggerProvider.cs
@@ -1,22 +1,20 @@
 ﻿using System.IO;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace Buildalyzer.Logging
+namespace Buildalyzer.Logging;
+
+public class TextWriterLoggerProvider : ILoggerProvider
 {
-    public class TextWriterLoggerProvider : ILoggerProvider
+    private readonly TextWriter _textWriter;
+
+    public TextWriterLoggerProvider(TextWriter textWriter)
     {
-        private readonly TextWriter _textWriter;
-
-        public TextWriterLoggerProvider(TextWriter textWriter)
-        {
-            _textWriter = textWriter;
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public ILogger CreateLogger(string categoryName) => new TextWriterLogger(_textWriter);
+        _textWriter = textWriter;
     }
+
+    public void Dispose()
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName) => new TextWriterLogger(_textWriter);
 }

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -14,389 +14,388 @@ using Microsoft.Extensions.Logging;
 using MsBuildPipeLogger;
 using ILogger = Microsoft.Build.Framework.ILogger;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class ProjectAnalyzer : IProjectAnalyzer
 {
-    public class ProjectAnalyzer : IProjectAnalyzer
+    private readonly List<ILogger> _buildLoggers = new List<ILogger>();
+
+    // Project-specific global properties and environment variables
+    private readonly ConcurrentDictionary<string, string> _globalProperties = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, string> _environmentVariables = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    public AnalyzerManager Manager { get; }
+
+    public IProjectFile ProjectFile { get; }
+
+    public EnvironmentFactory EnvironmentFactory { get; }
+
+    public string SolutionDirectory { get; }
+
+    public ProjectInSolution ProjectInSolution { get; }
+
+    /// <inheritdoc/>
+    public Guid ProjectGuid { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> GlobalProperties => GetEffectiveGlobalProperties(null);
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> EnvironmentVariables => GetEffectiveEnvironmentVariables(null);
+
+    public IEnumerable<ILogger> BuildLoggers => _buildLoggers;
+
+    public ILogger<ProjectAnalyzer> Logger { get; set; }
+
+    /// <inheritdoc/>
+    public bool IgnoreFaultyImports { get; set; } = true;
+
+    // The project file path should already be normalized
+    internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath, ProjectInSolution projectInSolution)
     {
-        private readonly List<ILogger> _buildLoggers = new List<ILogger>();
+        Manager = manager;
+        Logger = Manager.LoggerFactory?.CreateLogger<ProjectAnalyzer>();
+        ProjectFile = new ProjectFile(projectFilePath);
+        EnvironmentFactory = new EnvironmentFactory(Manager, ProjectFile);
+        ProjectInSolution = projectInSolution;
+        SolutionDirectory = (string.IsNullOrEmpty(manager.SolutionFilePath)
+            ? Path.GetDirectoryName(projectFilePath) : Path.GetDirectoryName(manager.SolutionFilePath)) + Path.DirectorySeparatorChar;
 
-        // Project-specific global properties and environment variables
-        private readonly ConcurrentDictionary<string, string> _globalProperties = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Get (or create) a project GUID
+        ProjectGuid = projectInSolution == null
+            ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFile.Name)
+            : Guid.Parse(projectInSolution.ProjectGuid);
 
-        private readonly ConcurrentDictionary<string, string> _environmentVariables = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Set the solution directory global property
+        SetGlobalProperty(MsBuildProperties.SolutionDir, SolutionDirectory);
+    }
 
-        public AnalyzerManager Manager { get; }
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string[] targetFrameworks) =>
+        Build(targetFrameworks, new EnvironmentOptions());
 
-        public IProjectFile ProjectFile { get; }
-
-        public EnvironmentFactory EnvironmentFactory { get; }
-
-        public string SolutionDirectory { get; }
-
-        public ProjectInSolution ProjectInSolution { get; }
-
-        /// <inheritdoc/>
-        public Guid ProjectGuid { get; }
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, string> GlobalProperties => GetEffectiveGlobalProperties(null);
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, string> EnvironmentVariables => GetEffectiveEnvironmentVariables(null);
-
-        public IEnumerable<ILogger> BuildLoggers => _buildLoggers;
-
-        public ILogger<ProjectAnalyzer> Logger { get; set; }
-
-        /// <inheritdoc/>
-        public bool IgnoreFaultyImports { get; set; } = true;
-
-        // The project file path should already be normalized
-        internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath, ProjectInSolution projectInSolution)
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string[] targetFrameworks, EnvironmentOptions environmentOptions)
+    {
+        if (environmentOptions == null)
         {
-            Manager = manager;
-            Logger = Manager.LoggerFactory?.CreateLogger<ProjectAnalyzer>();
-            ProjectFile = new ProjectFile(projectFilePath);
-            EnvironmentFactory = new EnvironmentFactory(Manager, ProjectFile);
-            ProjectInSolution = projectInSolution;
-            SolutionDirectory = (string.IsNullOrEmpty(manager.SolutionFilePath)
-                ? Path.GetDirectoryName(projectFilePath) : Path.GetDirectoryName(manager.SolutionFilePath)) + Path.DirectorySeparatorChar;
-
-            // Get (or create) a project GUID
-            ProjectGuid = projectInSolution == null
-                ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFile.Name)
-                : Guid.Parse(projectInSolution.ProjectGuid);
-
-            // Set the solution directory global property
-            SetGlobalProperty(MsBuildProperties.SolutionDir, SolutionDirectory);
+            throw new ArgumentNullException(nameof(environmentOptions));
         }
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string[] targetFrameworks) =>
-            Build(targetFrameworks, new EnvironmentOptions());
-
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string[] targetFrameworks, EnvironmentOptions environmentOptions)
+        // If the set of target frameworks is empty, just build the default
+        if (targetFrameworks == null || targetFrameworks.Length == 0)
         {
-            if (environmentOptions == null)
-            {
-                throw new ArgumentNullException(nameof(environmentOptions));
-            }
-
-            // If the set of target frameworks is empty, just build the default
-            if (targetFrameworks == null || targetFrameworks.Length == 0)
-            {
-                targetFrameworks = new string[] { null };
-            }
-
-            // Create a new build environment for each target
-            AnalyzerResults results = new AnalyzerResults();
-            foreach (string targetFramework in targetFrameworks)
-            {
-                BuildEnvironment buildEnvironment = EnvironmentFactory.GetBuildEnvironment(targetFramework, environmentOptions);
-                BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
-            }
-
-            return results;
+            targetFrameworks = new string[] { null };
         }
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string[] targetFrameworks, BuildEnvironment buildEnvironment)
+        // Create a new build environment for each target
+        AnalyzerResults results = new AnalyzerResults();
+        foreach (string targetFramework in targetFrameworks)
         {
-            if (buildEnvironment == null)
-            {
-                throw new ArgumentNullException(nameof(buildEnvironment));
-            }
-
-            // If the set of target frameworks is empty, just build the default
-            if (targetFrameworks == null || targetFrameworks.Length == 0)
-            {
-                targetFrameworks = new string[] { null };
-            }
-
-            AnalyzerResults results = new AnalyzerResults();
-            foreach (string targetFramework in targetFrameworks)
-            {
-                BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
-            }
-
-            return results;
+            BuildEnvironment buildEnvironment = EnvironmentFactory.GetBuildEnvironment(targetFramework, environmentOptions);
+            BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
         }
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string targetFramework) =>
-            Build(targetFramework, EnvironmentFactory.GetBuildEnvironment(targetFramework));
+        return results;
+    }
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string targetFramework, EnvironmentOptions environmentOptions) =>
-            Build(
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string[] targetFrameworks, BuildEnvironment buildEnvironment)
+    {
+        if (buildEnvironment == null)
+        {
+            throw new ArgumentNullException(nameof(buildEnvironment));
+        }
+
+        // If the set of target frameworks is empty, just build the default
+        if (targetFrameworks == null || targetFrameworks.Length == 0)
+        {
+            targetFrameworks = new string[] { null };
+        }
+
+        AnalyzerResults results = new AnalyzerResults();
+        foreach (string targetFramework in targetFrameworks)
+        {
+            BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string targetFramework) =>
+        Build(targetFramework, EnvironmentFactory.GetBuildEnvironment(targetFramework));
+
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string targetFramework, EnvironmentOptions environmentOptions) =>
+        Build(
+            targetFramework,
+            EnvironmentFactory.GetBuildEnvironment(
                 targetFramework,
-                EnvironmentFactory.GetBuildEnvironment(
-                    targetFramework,
-                    environmentOptions ?? throw new ArgumentNullException(nameof(environmentOptions))));
+                environmentOptions ?? throw new ArgumentNullException(nameof(environmentOptions))));
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment) =>
-            BuildTargets(
-                buildEnvironment ?? throw new ArgumentNullException(nameof(buildEnvironment)),
-                targetFramework,
-                buildEnvironment.TargetsToBuild,
-                new AnalyzerResults());
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment) =>
+        BuildTargets(
+            buildEnvironment ?? throw new ArgumentNullException(nameof(buildEnvironment)),
+            targetFramework,
+            buildEnvironment.TargetsToBuild,
+            new AnalyzerResults());
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build() => Build((string)null);
+    /// <inheritdoc/>
+    public IAnalyzerResults Build() => Build((string)null);
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(EnvironmentOptions environmentOptions) => Build((string)null, environmentOptions);
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(EnvironmentOptions environmentOptions) => Build((string)null, environmentOptions);
 
-        /// <inheritdoc/>
-        public IAnalyzerResults Build(BuildEnvironment buildEnvironment) => Build((string)null, buildEnvironment);
+    /// <inheritdoc/>
+    public IAnalyzerResults Build(BuildEnvironment buildEnvironment) => Build((string)null, buildEnvironment);
 
-        // This is where the magic happens - returns one result per result target framework
-        private IAnalyzerResults BuildTargets(
-            BuildEnvironment buildEnvironment, string targetFramework, string[] targetsToBuild, AnalyzerResults results)
+    // This is where the magic happens - returns one result per result target framework
+    private IAnalyzerResults BuildTargets(
+        BuildEnvironment buildEnvironment, string targetFramework, string[] targetsToBuild, AnalyzerResults results)
+    {
+        using (CancellationTokenSource cancellation = new CancellationTokenSource())
         {
-            using (CancellationTokenSource cancellation = new CancellationTokenSource())
+            using (AnonymousPipeLoggerServer pipeLogger = new AnonymousPipeLoggerServer(cancellation.Token))
             {
-                using (AnonymousPipeLoggerServer pipeLogger = new AnonymousPipeLoggerServer(cancellation.Token))
+                using (EventProcessor eventProcessor =
+                    new EventProcessor(Manager, this, BuildLoggers, pipeLogger, results != null))
                 {
-                    using (EventProcessor eventProcessor =
-                        new EventProcessor(Manager, this, BuildLoggers, pipeLogger, results != null))
+                    // Run MSBuild
+                    int exitCode;
+                    string fileName = GetCommand(
+                        buildEnvironment,
+                        targetFramework,
+                        targetsToBuild,
+                        pipeLogger.GetClientHandle(),
+                        out string arguments);
+                    using (ProcessRunner processRunner = new ProcessRunner(
+                        fileName,
+                        arguments,
+                        buildEnvironment.WorkingDirectory ?? Path.GetDirectoryName(ProjectFile.Path),
+                        GetEffectiveEnvironmentVariables(buildEnvironment),
+                        Manager.LoggerFactory))
                     {
-                        // Run MSBuild
-                        int exitCode;
-                        string fileName = GetCommand(
-                            buildEnvironment,
-                            targetFramework,
-                            targetsToBuild,
-                            pipeLogger.GetClientHandle(),
-                            out string arguments);
-                        using (ProcessRunner processRunner = new ProcessRunner(
-                            fileName,
-                            arguments,
-                            buildEnvironment.WorkingDirectory ?? Path.GetDirectoryName(ProjectFile.Path),
-                            GetEffectiveEnvironmentVariables(buildEnvironment),
-                            Manager.LoggerFactory))
-                        {
-                            processRunner.Start();
-                            pipeLogger.ReadAll();
-                            processRunner.WaitForExit();
-                            exitCode = processRunner.ExitCode;
-                        }
-
-                        // Collect the results
-                        results?.Add(eventProcessor.Results, exitCode == 0 && eventProcessor.OverallSuccess);
+                        processRunner.Start();
+                        pipeLogger.ReadAll();
+                        processRunner.WaitForExit();
+                        exitCode = processRunner.ExitCode;
                     }
+
+                    // Collect the results
+                    results?.Add(eventProcessor.Results, exitCode == 0 && eventProcessor.OverallSuccess);
                 }
             }
-            return results;
+        }
+        return results;
+    }
+
+    private string GetCommand(
+        BuildEnvironment buildEnvironment,
+        string targetFramework,
+        string[] targetsToBuild,
+        string pipeLoggerClientHandle,
+        out string arguments)
+    {
+        // Get the executable and the initial set of arguments
+        string fileName = buildEnvironment.MsBuildExePath;
+        string initialArguments = string.Empty;
+        bool isDotNet = false; // false=MSBuild.exe, true=dotnet.exe
+        if (string.IsNullOrWhiteSpace(buildEnvironment.MsBuildExePath)
+            || Path.GetExtension(buildEnvironment.MsBuildExePath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            // in case of no MSBuild path or a path to the MSBuild dll, run dotnet
+            fileName = buildEnvironment.DotnetExePath;
+            isDotNet = true;
+            if (!string.IsNullOrWhiteSpace(buildEnvironment.MsBuildExePath))
+            {
+                // pass path to MSBuild .dll to dotnet if provided
+                initialArguments = $"\"{buildEnvironment.MsBuildExePath}\"";
+            }
         }
 
-        private string GetCommand(
-            BuildEnvironment buildEnvironment,
-            string targetFramework,
-            string[] targetsToBuild,
-            string pipeLoggerClientHandle,
-            out string arguments)
+        // Get the rest of the arguments
+        List<string> argumentsList = new List<string>();
+
+        // Environment arguments
+        if (buildEnvironment.Arguments.Any())
         {
-            // Get the executable and the initial set of arguments
-            string fileName = buildEnvironment.MsBuildExePath;
-            string initialArguments = string.Empty;
-            bool isDotNet = false; // false=MSBuild.exe, true=dotnet.exe
-            if (string.IsNullOrWhiteSpace(buildEnvironment.MsBuildExePath)
-                || Path.GetExtension(buildEnvironment.MsBuildExePath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+            argumentsList.Add(string.Join(" ", buildEnvironment.Arguments));
+        }
+
+        // Get the restore argument (/restore)
+        if (buildEnvironment.Restore)
+        {
+            argumentsList.Add("/restore");
+        }
+
+        // Get the target argument (/target)
+        if (targetsToBuild != null && targetsToBuild.Length != 0)
+        {
+            argumentsList.Add($"/target:{string.Join(";", targetsToBuild)}");
+        }
+
+        // Get the properties arguments (/property)
+        Dictionary<string, string> effectiveGlobalProperties = GetEffectiveGlobalProperties(buildEnvironment);
+        if (!string.IsNullOrEmpty(targetFramework))
+        {
+            // Setting the TargetFramework MSBuild property tells MSBuild which target framework to use for the outer build
+            effectiveGlobalProperties[MsBuildProperties.TargetFramework] = targetFramework;
+        }
+        if (Path.GetExtension(ProjectFile.Path).Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
+            && effectiveGlobalProperties.ContainsKey(MsBuildProperties.SkipCompilerExecution))
+        {
+            // We can't skip the compiler for design-time builds in F# (it causes strange errors regarding file copying)
+            effectiveGlobalProperties.Remove(MsBuildProperties.SkipCompilerExecution);
+        }
+        string propertyArgStart = "/property"; // in case of MSBuild.exe use slash as parameter prefix for property
+        if (isDotNet)
+        {
+            // in case of dotnet.exe use dash as parameter prefix for property
+            propertyArgStart = "-p";
+        }
+        if (effectiveGlobalProperties.Count > 0)
+        {
+            argumentsList.Add(
+                propertyArgStart
+                    + $":{string.Join(";", effectiveGlobalProperties.Select(x => $"{x.Key}={FormatArgument(x.Value)}"))}");
+        }
+
+        // Get the logger arguments (/l)
+        string loggerPath = typeof(BuildalyzerLogger).Assembly.Location;
+        bool logEverything = _buildLoggers.Count > 0;
+        string loggerArgStart = "/l"; // in case of MSBuild.exe use slash as parameter prefix for logger
+        if (isDotNet)
+        {
+            // in case of dotnet.exe use dash as parameter prefix for logger
+            loggerArgStart = "-l";
+        }
+        argumentsList.Add(loggerArgStart + $":{nameof(BuildalyzerLogger)},{FormatArgument(loggerPath)};{pipeLoggerClientHandle};{logEverything}");
+
+        // Get the noAutoResponse argument (/noAutoResponse)
+        // See https://github.com/daveaglick/Buildalyzer/issues/211
+        // and https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files
+        if (buildEnvironment.NoAutoResponse)
+        {
+            argumentsList.Add("/noAutoResponse");
+        }
+
+        // Path argument
+        argumentsList.Add(FormatArgument(ProjectFile.Path));
+
+        // Combine the arguments
+        arguments = string.Empty;
+        if (!isDotNet || !string.IsNullOrEmpty(initialArguments))
+        {
+            // these are the first arguments for MSBuild.exe or dotnet.exe with MSBuild.dll, they are not needed for pure dotnet.exe calls
+            arguments = $"{initialArguments} /noconsolelogger ";
+        }
+        arguments += string.Join(" ", argumentsList);
+
+        return fileName;
+    }
+
+    private static string FormatArgument(string argument)
+    {
+        // Escape inner quotes
+        argument = argument.Replace("\"", "\\\"");
+
+        // Also escape trailing slashes so they don't escape the closing quote
+        if (argument.EndsWith("\\"))
+        {
+            argument = $"{argument}\\";
+        }
+
+        // Surround with quotes
+        return $"\"{argument}\"";
+    }
+
+    public void SetGlobalProperty(string key, string value)
+    {
+        _globalProperties[key] = value;
+    }
+
+    public void RemoveGlobalProperty(string key)
+    {
+        // Nulls are removed before passing to MSBuild and can be used to ignore values in lower-precedence collections
+        _globalProperties[key] = null;
+    }
+
+    public void SetEnvironmentVariable(string key, string value)
+    {
+        _environmentVariables[key] = value;
+    }
+
+    // Note the order of precedence (from least to most)
+    private Dictionary<string, string> GetEffectiveGlobalProperties(BuildEnvironment buildEnvironment)
+        => GetEffectiveDictionary(
+            true,  // Remove nulls to avoid passing null global properties. But null can be used in higher-precident dictionaries to ignore a lower-precident dictionary's value.
+            buildEnvironment?.GlobalProperties,
+            Manager.GlobalProperties,
+            _globalProperties);
+
+    // Note the order of precedence (from least to most)
+    private Dictionary<string, string> GetEffectiveEnvironmentVariables(BuildEnvironment buildEnvironment)
+        => GetEffectiveDictionary(
+            false, // Don't remove nulls as a null value will unset the env var which may be set by a calling process.
+            buildEnvironment?.EnvironmentVariables,
+            Manager.EnvironmentVariables,
+            _environmentVariables);
+
+    private static Dictionary<string, string> GetEffectiveDictionary(
+        bool removeNulls,
+        params IReadOnlyDictionary<string, string>[] innerDictionaries)
+    {
+        Dictionary<string, string> effectiveDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (IReadOnlyDictionary<string, string> innerDictionary in innerDictionaries.Where(x => x != null))
+        {
+            foreach (KeyValuePair<string, string> pair in innerDictionary)
             {
-                // in case of no MSBuild path or a path to the MSBuild dll, run dotnet
-                fileName = buildEnvironment.DotnetExePath;
-                isDotNet = true;
-                if (!string.IsNullOrWhiteSpace(buildEnvironment.MsBuildExePath))
+                if (removeNulls && pair.Value == null)
                 {
-                    // pass path to MSBuild .dll to dotnet if provided
-                    initialArguments = $"\"{buildEnvironment.MsBuildExePath}\"";
+                    effectiveDictionary.Remove(pair.Key);
+                }
+                else
+                {
+                    effectiveDictionary[pair.Key] = pair.Value;
                 }
             }
-
-            // Get the rest of the arguments
-            List<string> argumentsList = new List<string>();
-
-            // Environment arguments
-            if (buildEnvironment.Arguments.Any())
-            {
-                argumentsList.Add(string.Join(" ", buildEnvironment.Arguments));
-            }
-
-            // Get the restore argument (/restore)
-            if (buildEnvironment.Restore)
-            {
-                argumentsList.Add("/restore");
-            }
-
-            // Get the target argument (/target)
-            if (targetsToBuild != null && targetsToBuild.Length != 0)
-            {
-                argumentsList.Add($"/target:{string.Join(";", targetsToBuild)}");
-            }
-
-            // Get the properties arguments (/property)
-            Dictionary<string, string> effectiveGlobalProperties = GetEffectiveGlobalProperties(buildEnvironment);
-            if (!string.IsNullOrEmpty(targetFramework))
-            {
-                // Setting the TargetFramework MSBuild property tells MSBuild which target framework to use for the outer build
-                effectiveGlobalProperties[MsBuildProperties.TargetFramework] = targetFramework;
-            }
-            if (Path.GetExtension(ProjectFile.Path).Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
-                && effectiveGlobalProperties.ContainsKey(MsBuildProperties.SkipCompilerExecution))
-            {
-                // We can't skip the compiler for design-time builds in F# (it causes strange errors regarding file copying)
-                effectiveGlobalProperties.Remove(MsBuildProperties.SkipCompilerExecution);
-            }
-            string propertyArgStart = "/property"; // in case of MSBuild.exe use slash as parameter prefix for property
-            if (isDotNet)
-            {
-                // in case of dotnet.exe use dash as parameter prefix for property
-                propertyArgStart = "-p";
-            }
-            if (effectiveGlobalProperties.Count > 0)
-            {
-                argumentsList.Add(
-                    propertyArgStart
-                        + $":{string.Join(";", effectiveGlobalProperties.Select(x => $"{x.Key}={FormatArgument(x.Value)}"))}");
-            }
-
-            // Get the logger arguments (/l)
-            string loggerPath = typeof(BuildalyzerLogger).Assembly.Location;
-            bool logEverything = _buildLoggers.Count > 0;
-            string loggerArgStart = "/l"; // in case of MSBuild.exe use slash as parameter prefix for logger
-            if (isDotNet)
-            {
-                // in case of dotnet.exe use dash as parameter prefix for logger
-                loggerArgStart = "-l";
-            }
-            argumentsList.Add(loggerArgStart + $":{nameof(BuildalyzerLogger)},{FormatArgument(loggerPath)};{pipeLoggerClientHandle};{logEverything}");
-
-            // Get the noAutoResponse argument (/noAutoResponse)
-            // See https://github.com/daveaglick/Buildalyzer/issues/211
-            // and https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files
-            if (buildEnvironment.NoAutoResponse)
-            {
-                argumentsList.Add("/noAutoResponse");
-            }
-
-            // Path argument
-            argumentsList.Add(FormatArgument(ProjectFile.Path));
-
-            // Combine the arguments
-            arguments = string.Empty;
-            if (!isDotNet || !string.IsNullOrEmpty(initialArguments))
-            {
-                // these are the first arguments for MSBuild.exe or dotnet.exe with MSBuild.dll, they are not needed for pure dotnet.exe calls
-                arguments = $"{initialArguments} /noconsolelogger ";
-            }
-            arguments += string.Join(" ", argumentsList);
-
-            return fileName;
         }
 
-        private static string FormatArgument(string argument)
+        return effectiveDictionary;
+    }
+
+    public void AddBinaryLogger(
+        string binaryLogFilePath = null,
+        BinaryLogger.ProjectImportsCollectionMode collectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed) =>
+        AddBuildLogger(new BinaryLogger
         {
-            // Escape inner quotes
-            argument = argument.Replace("\"", "\\\"");
+            Parameters = binaryLogFilePath ?? Path.ChangeExtension(ProjectFile.Path, "binlog"),
+            CollectProjectImports = collectProjectImports,
+            Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic
+        });
 
-            // Also escape trailing slashes so they don't escape the closing quote
-            if (argument.EndsWith("\\"))
-            {
-                argument = $"{argument}\\";
-            }
-
-            // Surround with quotes
-            return $"\"{argument}\"";
-        }
-
-        public void SetGlobalProperty(string key, string value)
+    /// <inheritdoc/>
+    public void AddBuildLogger(ILogger logger)
+    {
+        if (logger == null)
         {
-            _globalProperties[key] = value;
+            throw new ArgumentNullException(nameof(logger));
         }
 
-        public void RemoveGlobalProperty(string key)
+        _buildLoggers.Add(logger);
+    }
+
+    /// <inheritdoc/>
+    public void RemoveBuildLogger(ILogger logger)
+    {
+        if (logger == null)
         {
-            // Nulls are removed before passing to MSBuild and can be used to ignore values in lower-precedence collections
-            _globalProperties[key] = null;
+            throw new ArgumentNullException(nameof(logger));
         }
 
-        public void SetEnvironmentVariable(string key, string value)
-        {
-            _environmentVariables[key] = value;
-        }
-
-        // Note the order of precedence (from least to most)
-        private Dictionary<string, string> GetEffectiveGlobalProperties(BuildEnvironment buildEnvironment)
-            => GetEffectiveDictionary(
-                true,  // Remove nulls to avoid passing null global properties. But null can be used in higher-precident dictionaries to ignore a lower-precident dictionary's value.
-                buildEnvironment?.GlobalProperties,
-                Manager.GlobalProperties,
-                _globalProperties);
-
-        // Note the order of precedence (from least to most)
-        private Dictionary<string, string> GetEffectiveEnvironmentVariables(BuildEnvironment buildEnvironment)
-            => GetEffectiveDictionary(
-                false, // Don't remove nulls as a null value will unset the env var which may be set by a calling process.
-                buildEnvironment?.EnvironmentVariables,
-                Manager.EnvironmentVariables,
-                _environmentVariables);
-
-        private static Dictionary<string, string> GetEffectiveDictionary(
-            bool removeNulls,
-            params IReadOnlyDictionary<string, string>[] innerDictionaries)
-        {
-            Dictionary<string, string> effectiveDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (IReadOnlyDictionary<string, string> innerDictionary in innerDictionaries.Where(x => x != null))
-            {
-                foreach (KeyValuePair<string, string> pair in innerDictionary)
-                {
-                    if (removeNulls && pair.Value == null)
-                    {
-                        effectiveDictionary.Remove(pair.Key);
-                    }
-                    else
-                    {
-                        effectiveDictionary[pair.Key] = pair.Value;
-                    }
-                }
-            }
-
-            return effectiveDictionary;
-        }
-
-        public void AddBinaryLogger(
-            string binaryLogFilePath = null,
-            BinaryLogger.ProjectImportsCollectionMode collectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed) =>
-            AddBuildLogger(new BinaryLogger
-            {
-                Parameters = binaryLogFilePath ?? Path.ChangeExtension(ProjectFile.Path, "binlog"),
-                CollectProjectImports = collectProjectImports,
-                Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic
-            });
-
-        /// <inheritdoc/>
-        public void AddBuildLogger(ILogger logger)
-        {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            _buildLoggers.Add(logger);
-        }
-
-        /// <inheritdoc/>
-        public void RemoveBuildLogger(ILogger logger)
-        {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            _buildLoggers.Remove(logger);
-        }
+        _buildLoggers.Remove(logger);
     }
 }

--- a/src/Buildalyzer/ProjectItem.cs
+++ b/src/Buildalyzer/ProjectItem.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Logging;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+public class ProjectItem : IProjectItem
 {
-    public class ProjectItem : IProjectItem
-    {
-        public string ItemSpec { get; }
-        public IReadOnlyDictionary<string, string> Metadata { get; }
+    public string ItemSpec { get; }
+    public IReadOnlyDictionary<string, string> Metadata { get; }
 
-        internal ProjectItem(ITaskItem taskItem)
-        {
-            ItemSpec = taskItem.ItemSpec;
-            Metadata = taskItem.MetadataNames.Cast<string>().ToDictionary(x => x, x => taskItem.GetMetadata(x));
-        }
+    internal ProjectItem(ITaskItem taskItem)
+    {
+        ItemSpec = taskItem.ItemSpec;
+        Metadata = taskItem.MetadataNames.Cast<string>().ToDictionary(x => x, x => taskItem.GetMetadata(x));
     }
 }

--- a/src/Buildalyzer/XDocumentExtensions.cs
+++ b/src/Buildalyzer/XDocumentExtensions.cs
@@ -3,21 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
-namespace Buildalyzer
+namespace Buildalyzer;
+
+internal static class XDocumentExtensions
 {
-    internal static class XDocumentExtensions
-    {
-        public static IEnumerable<XElement> GetDescendants(this XDocument document, string name) =>
-            document.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+    public static IEnumerable<XElement> GetDescendants(this XDocument document, string name) =>
+        document.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
 
-        public static IEnumerable<XElement> GetDescendants(this XElement element, string name) =>
-            element.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+    public static IEnumerable<XElement> GetDescendants(this XElement element, string name) =>
+        element.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
 
-        public static string GetAttributeValue(this XElement element, string name) =>
-            element.Attributes().FirstOrDefault(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value;
+    public static string GetAttributeValue(this XElement element, string name) =>
+        element.Attributes().FirstOrDefault(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value;
 
-        // Adds a child element with the same namespace as the parent
-        public static void AddChildElement(this XElement element, string name, string value) =>
-            element.Add(new XElement(XName.Get(name, element.Name.NamespaceName), value));
-    }
+    // Adds a child element with the same namespace as the parent
+    public static void AddChildElement(this XElement element, string name, string value) =>
+        element.Add(new XElement(XName.Get(name, element.Name.NamespaceName), value));
 }

--- a/tests/Buildalyzer.Tests/AnalyzerResultFixture.cs
+++ b/tests/Buildalyzer.Tests/AnalyzerResultFixture.cs
@@ -1,214 +1,211 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Tests
+namespace Buildalyzer.Tests;
+
+[TestFixture]
+public class AnalyzerResultFixture
 {
-    [TestFixture]
-    public class AnalyzerResultFixture
+    private const string CscOptions = "/noconfig /unsafe- /checked- /nowarn:1701,1702,1701,1702,1701,1702 /nostdlib+ /errorreport:prompt /warn:4 /define:TRACE;DEBUG;NETCOREAPP;NETCOREAPP2_1 ";
+    private const string VbcOptions = "/noconfig /imports:Microsoft.VisualBasic,System,System.Collections,System.Collections.Generic,System.Diagnostics,System.Linq,System.Xml.Linq,System.Threading.Tasks /optioncompare:Binary /optionexplicit+ /optionstrict:custom /nowarn:41999,42016,42017,42018,42019,42020,42021,42022,42032,42036 /nosdkpath /optioninfer+ /nostdlib /errorreport:prompt /rootnamespace:ConsoleApp21 /highentropyva+ /define:CONFIG=Debug,DEBUG=-1 /warnaserror+:NU1605 ";
+
+    [TestCase("foo.cs", new[] { "foo.cs" })]
+    [TestCase("foo.cs bar.cs", new[] { "foo.cs", "bar.cs" })]
+    [TestCase("\"foo.cs\"", new[] { "foo.cs" })]
+    [TestCase("\"fizz buzz.cs\"", new[] { "fizz buzz.cs" })]
+    [TestCase("foo.cs \"fizz buzz.cs\"", new[] { "foo.cs", "fizz buzz.cs" })]
+    [TestCase("\"fizz - buzz.cs\"", new[] { "fizz - buzz.cs" })] // #89
+    [TestCase("\"f oo.cs\"", new[] { "f oo.cs" })]
+    [TestCase("\" foo.cs\"", new[] { " foo.cs" })]
+    [TestCase("\"foo.cs \"", new[] { "foo.cs " })]
+    [TestCase("\"foo.cs\\\"\"", new[] { "foo.cs\"" })]
+    [TestCase("\"f oo.cs\" bar.cs", new[] { "f oo.cs", "bar.cs" })]
+    [TestCase("\" foo.cs\" bar.cs", new[] { " foo.cs", "bar.cs" })]
+    [TestCase("\"foo.cs \" bar.cs", new[] { "foo.cs ", "bar.cs" })]
+    [TestCase("\"foo.cs\\\"\" bar.cs", new[] { "foo.cs\"", "bar.cs" })]
+    [TestCase("\"fo\\\"o.cs\" bar.cs", new[] { "fo\"o.cs", "bar.cs" })]
+    [TestCase("bar.cs \"f oo.cs\"", new[] { "bar.cs", "f oo.cs" })]
+    [TestCase("bar.cs \" foo.cs\"", new[] { "bar.cs", " foo.cs" })]
+    [TestCase("bar.cs \"foo.cs\\\"\"", new[] { "bar.cs", "foo.cs\"" })]
+    [TestCase("\"foo.cs\\\" bar.cs\"", new[] { "foo.cs\" bar.cs" })]
+    public void ParsesCscCommandLineSourceFiles(string commandLine, string[] sourceFiles)
     {
-        private const string CscOptions = "/noconfig /unsafe- /checked- /nowarn:1701,1702,1701,1702,1701,1702 /nostdlib+ /errorreport:prompt /warn:4 /define:TRACE;DEBUG;NETCOREAPP;NETCOREAPP2_1 ";
-        private const string VbcOptions = "/noconfig /imports:Microsoft.VisualBasic,System,System.Collections,System.Collections.Generic,System.Diagnostics,System.Linq,System.Xml.Linq,System.Threading.Tasks /optioncompare:Binary /optionexplicit+ /optionstrict:custom /nowarn:41999,42016,42017,42018,42019,42020,42021,42022,42032,42036 /nosdkpath /optioninfer+ /nostdlib /errorreport:prompt /rootnamespace:ConsoleApp21 /highentropyva+ /define:CONFIG=Debug,DEBUG=-1 /warnaserror+:NU1605 ";
+        // Given
+        commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe") + " "
+            + CscOptions
+            + commandLine;
 
-        [TestCase("foo.cs", new[] { "foo.cs" })]
-        [TestCase("foo.cs bar.cs", new[] { "foo.cs", "bar.cs" })]
-        [TestCase("\"foo.cs\"", new[] { "foo.cs" })]
-        [TestCase("\"fizz buzz.cs\"", new[] { "fizz buzz.cs" })]
-        [TestCase("foo.cs \"fizz buzz.cs\"", new[] { "foo.cs", "fizz buzz.cs" })]
-        [TestCase("\"fizz - buzz.cs\"", new[] { "fizz - buzz.cs" })] // #89
-        [TestCase("\"f oo.cs\"", new[] { "f oo.cs" })]
-        [TestCase("\" foo.cs\"", new[] { " foo.cs" })]
-        [TestCase("\"foo.cs \"", new[] { "foo.cs " })]
-        [TestCase("\"foo.cs\\\"\"", new[] { "foo.cs\"" })]
-        [TestCase("\"f oo.cs\" bar.cs", new[] { "f oo.cs", "bar.cs" })]
-        [TestCase("\" foo.cs\" bar.cs", new[] { " foo.cs", "bar.cs" })]
-        [TestCase("\"foo.cs \" bar.cs", new[] { "foo.cs ", "bar.cs" })]
-        [TestCase("\"foo.cs\\\"\" bar.cs", new[] { "foo.cs\"", "bar.cs" })]
-        [TestCase("\"fo\\\"o.cs\" bar.cs", new[] { "fo\"o.cs", "bar.cs" })]
-        [TestCase("bar.cs \"f oo.cs\"", new[] { "bar.cs", "f oo.cs" })]
-        [TestCase("bar.cs \" foo.cs\"", new[] { "bar.cs", " foo.cs" })]
-        [TestCase("bar.cs \"foo.cs\\\"\"", new[] { "bar.cs", "foo.cs\"" })]
-        [TestCase("\"foo.cs\\\" bar.cs\"", new[] { "foo.cs\" bar.cs" })]
-        public void ParsesCscCommandLineSourceFiles(string commandLine, string[] sourceFiles)
-        {
-            // Given
-            commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe") + " "
-                + CscOptions
-                + commandLine;
+        // When
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
 
-            // When
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
+        result.Arguments.ShouldBe(CscOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(sourceFiles));
+        result.ProcessedArguments.Where(x => x.Item1 == null).Select(x => x.Item2).Skip(1).ShouldBe(sourceFiles);
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
-            result.Arguments.ShouldBe(CscOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(sourceFiles));
-            result.ProcessedArguments.Where(x => x.Item1 == null).Select(x => x.Item2).Skip(1).ShouldBe(sourceFiles);
-        }
+    [TestCase("foo.cs bar.cs csc.dll", new[] { "foo.cs", "bar.cs" })]
+    [TestCase("foo.cs csc.exe bar.cs", new[] { "foo.cs", "bar.cs" })]
+    [TestCase("foo.cs bar.cs", new[] { "foo.cs", "bar.cs" })]
+    [SuppressMessage("CA1062", "CA1062:Validate arguments of public methods", Justification = "Test")]
+    public void RemovesCscAssembliesFromSourceFiles(string input, string[] sourceFiles)
+    {
+        // Given
+        string commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe") + " "
+            + CscOptions
+            + input;
+        string projectFilePath = Path.Combine("/", "Code", "Project", "project.csproj");
+        AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
 
-        [TestCase("foo.cs bar.cs csc.dll", new[] { "foo.cs", "bar.cs" })]
-        [TestCase("foo.cs csc.exe bar.cs", new[] { "foo.cs", "bar.cs" })]
-        [TestCase("foo.cs bar.cs", new[] { "foo.cs", "bar.cs" })]
-        [SuppressMessage("CA1062", "CA1062:Validate arguments of public methods", Justification = "Test")]
-        public void RemovesCscAssembliesFromSourceFiles(string input, string[] sourceFiles)
-        {
-            // Given
-            string commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe") + " "
-                + CscOptions
-                + input;
-            string projectFilePath = Path.Combine("/", "Code", "Project", "project.csproj");
-            AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
+        // When
+        result.ProcessCscCommandLine(commandLine, false);
 
-            // When
-            result.ProcessCscCommandLine(commandLine, false);
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.CompilerFilePath.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
+        result.CompilerArguments.ShouldBe(CscOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(input.Split(' ', StringSplitOptions.RemoveEmptyEntries)));
+        result.SourceFiles.ShouldBe(sourceFiles.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFilePath), x))));
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.CompilerFilePath.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
-            result.CompilerArguments.ShouldBe(CscOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(input.Split(' ', StringSplitOptions.RemoveEmptyEntries)));
-            result.SourceFiles.ShouldBe(sourceFiles.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFilePath), x))));
-        }
+    [Test]
+    public void ParsesCscCommandLineWithAliasReference()
+    {
+        // Given
+        string commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe")
+            + @" /reference:Data1=""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll""";
 
-        [Test]
-        public void ParsesCscCommandLineWithAliasReference()
-        {
-            // Given
-            string commandLine = Path.Combine("/", "Fizz", "Buzz", "csc.exe")
-                + @" /reference:Data1=""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll""";
+        // When
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
 
-            // When
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
+        result.Arguments.ShouldBe(new[] { @"/reference:Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll" });
+        result.ProcessedArguments.Count.ShouldBe(2);
+        result.ProcessedArguments.Where(x => x.Item1 == "reference")
+            .Select(x => x.Item2)
+            .Single()
+            .ShouldBe(@"Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll");
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "csc.exe"));
-            result.Arguments.ShouldBe(new[] { @"/reference:Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll" });
-            result.ProcessedArguments.Count.ShouldBe(2);
-            result.ProcessedArguments.Where(x => x.Item1 == "reference")
-                .Select(x => x.Item2)
-                .Single()
-                .ShouldBe(@"Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll");
-        }
+    [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\Roslyn\\csc.exe /noconfig")]
+    [TestCase("/one two/three/csc.dll /noconfig")]
+    [SuppressMessage("CA1062", "CA1062:Validate arguments of public methods", Justification = "Test")]
+    public void TreatsCscCommandAsSingleArg(string commandLine)
+    {
+        // Given, When
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
 
-        [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\Roslyn\\csc.exe /noconfig")]
-        [TestCase("/one two/three/csc.dll /noconfig")]
-        [SuppressMessage("CA1062", "CA1062:Validate arguments of public methods", Justification = "Test")]
-        public void TreatsCscCommandAsSingleArg(string commandLine)
-        {
-            // Given, When
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCscCommandLine(commandLine);
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.FileName.ShouldBe(commandLine.Replace(" /noconfig", string.Empty));
+        result.Arguments.ShouldBe(new[] { "/noconfig" });
+        result.ProcessedArguments.Count.ShouldBe(2);
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.FileName.ShouldBe(commandLine.Replace(" /noconfig", string.Empty));
-            result.Arguments.ShouldBe(new[] { "/noconfig" });
-            result.ProcessedArguments.Count.ShouldBe(2);
-        }
+    [TestCase("foo.vb", new[] { "foo.vb" })]
+    [TestCase("foo.vb bar.vb", new[] { "foo.vb", "bar.vb" })]
+    [TestCase("\"foo.vb\"", new[] { "foo.vb" })]
+    [TestCase("\"fizz buzz.vb\"", new[] { "fizz buzz.vb" })]
+    [TestCase("foo.vb \"fizz buzz.vb\"", new[] { "foo.vb", "fizz buzz.vb" })]
+    [TestCase("\"fizz - buzz.vb\"", new[] { "fizz - buzz.vb" })] // #89
+    [TestCase("\"f oo.vb\"", new[] { "f oo.vb" })]
+    [TestCase("\" foo.vb\"", new[] { " foo.vb" })]
+    [TestCase("\"foo.vb \"", new[] { "foo.vb " })]
+    [TestCase("\"foo.vb\\\"\"", new[] { "foo.vb\"" })]
+    [TestCase("\"f oo.vb\" bar.vb", new[] { "f oo.vb", "bar.vb" })]
+    [TestCase("\" foo.vb\" bar.vb", new[] { " foo.vb", "bar.vb" })]
+    [TestCase("\"foo.vb \" bar.vb", new[] { "foo.vb ", "bar.vb" })]
+    [TestCase("\"foo.vb\\\"\" bar.vb", new[] { "foo.vb\"", "bar.vb" })]
+    [TestCase("\"fo\\\"o.vb\" bar.vb", new[] { "fo\"o.vb", "bar.vb" })]
+    [TestCase("bar.vb \"f oo.vb\"", new[] { "bar.vb", "f oo.vb" })]
+    [TestCase("bar.vb \" foo.vb\"", new[] { "bar.vb", " foo.vb" })]
+    [TestCase("bar.vb \"foo.vb\\\"\"", new[] { "bar.vb", "foo.vb\"" })]
+    [TestCase("\"foo.vb\\\" bar.vb\"", new[] { "foo.vb\" bar.vb" })]
+    public void ParsesVbcCommandLineSourceFiles(string input, string[] sourceFiles)
+    {
+        // Given
+        string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe") + " "
+            + VbcOptions
+            + input;
 
-        [TestCase("foo.vb", new[] { "foo.vb" })]
-        [TestCase("foo.vb bar.vb", new[] { "foo.vb", "bar.vb" })]
-        [TestCase("\"foo.vb\"", new[] { "foo.vb" })]
-        [TestCase("\"fizz buzz.vb\"", new[] { "fizz buzz.vb" })]
-        [TestCase("foo.vb \"fizz buzz.vb\"", new[] { "foo.vb", "fizz buzz.vb" })]
-        [TestCase("\"fizz - buzz.vb\"", new[] { "fizz - buzz.vb" })] // #89
-        [TestCase("\"f oo.vb\"", new[] { "f oo.vb" })]
-        [TestCase("\" foo.vb\"", new[] { " foo.vb" })]
-        [TestCase("\"foo.vb \"", new[] { "foo.vb " })]
-        [TestCase("\"foo.vb\\\"\"", new[] { "foo.vb\"" })]
-        [TestCase("\"f oo.vb\" bar.vb", new[] { "f oo.vb", "bar.vb" })]
-        [TestCase("\" foo.vb\" bar.vb", new[] { " foo.vb", "bar.vb" })]
-        [TestCase("\"foo.vb \" bar.vb", new[] { "foo.vb ", "bar.vb" })]
-        [TestCase("\"foo.vb\\\"\" bar.vb", new[] { "foo.vb\"", "bar.vb" })]
-        [TestCase("\"fo\\\"o.vb\" bar.vb", new[] { "fo\"o.vb", "bar.vb" })]
-        [TestCase("bar.vb \"f oo.vb\"", new[] { "bar.vb", "f oo.vb" })]
-        [TestCase("bar.vb \" foo.vb\"", new[] { "bar.vb", " foo.vb" })]
-        [TestCase("bar.vb \"foo.vb\\\"\"", new[] { "bar.vb", "foo.vb\"" })]
-        [TestCase("\"foo.vb\\\" bar.vb\"", new[] { "foo.vb\" bar.vb" })]
-        public void ParsesVbcCommandLineSourceFiles(string input, string[] sourceFiles)
-        {
-            // Given
-            string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe") + " "
-                + VbcOptions
-                + input;
+        // When
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
 
-            // When
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "vbc.exe"));
+        result.Arguments.ShouldBe(VbcOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(sourceFiles));
+        result.ProcessedArguments.Where(x => x.Item1 == null).Select(x => x.Item2).Skip(1).ShouldBe(sourceFiles);
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "vbc.exe"));
-            result.Arguments.ShouldBe(VbcOptions.Split(' ', StringSplitOptions.RemoveEmptyEntries).Concat(sourceFiles));
-            result.ProcessedArguments.Where(x => x.Item1 == null).Select(x => x.Item2).Skip(1).ShouldBe(sourceFiles);
-        }
+    [TestCase("foo.vb bar.vb vbc.dll", new[] { "foo.vb", "bar.vb" })]
+    [TestCase("foo.vb vbc.exe bar.vb", new[] { "foo.vb", "bar.vb" })]
+    [TestCase("foo.vb bar.vb", new[] { "foo.vb", "bar.vb" })]
+    public void RemovesVbcAssembliesFromSourceFiles(string commandLine, string[] sourceFiles)
+    {
+        // Given
+        commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe") + " "
+            + VbcOptions
+            + commandLine;
+        string projectFilePath = Path.Combine("/", "Code", "Project", "project.vbproj");
+        AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
 
-        [TestCase("foo.vb bar.vb vbc.dll", new[] { "foo.vb", "bar.vb" })]
-        [TestCase("foo.vb vbc.exe bar.vb", new[] { "foo.vb", "bar.vb" })]
-        [TestCase("foo.vb bar.vb", new[] { "foo.vb", "bar.vb" })]
-        public void RemovesVbcAssembliesFromSourceFiles(string commandLine, string[] sourceFiles)
-        {
-            // Given
-            commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe") + " "
-                + VbcOptions
-                + commandLine;
-            string projectFilePath = Path.Combine("/", "Code", "Project", "project.vbproj");
-            AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
+        // When
+        result.ProcessVbcCommandLine(commandLine);
 
-            // When
-            result.ProcessVbcCommandLine(commandLine);
+        // Then
+        result.SourceFiles.ShouldBe(sourceFiles.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFilePath), x))));
+    }
 
-            // Then
-            result.SourceFiles.ShouldBe(sourceFiles.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFilePath), x))));
-        }
+    [Test]
+    public void ParsesVbcCommandLineWithAliasReference()
+    {
+        // Given
+        string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe")
+            + @" /reference:Data1=""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll""";
 
-        [Test]
-        public void ParsesVbcCommandLineWithAliasReference()
-        {
-            // Given
-            string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe")
-                + @" /reference:Data1=""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll""";
+        // When
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
 
-            // When
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
+        // Then
+        result.Command.ShouldBe(commandLine);
+        result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "vbc.exe"));
+        result.Arguments.ShouldBe(new[] { @"/reference:Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll" });
+        result.ProcessedArguments.Count.ShouldBe(2);
+        result.ProcessedArguments.Where(x => x.Item1 == "reference")
+            .Select(x => x.Item2)
+            .Single()
+            .ShouldBe(@"Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll");
+    }
 
-            // Then
-            result.Command.ShouldBe(commandLine);
-            result.FileName.ShouldBe(Path.Combine("/", "Fizz", "Buzz", "vbc.exe"));
-            result.Arguments.ShouldBe(new[] { @"/reference:Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll" });
-            result.ProcessedArguments.Count.ShouldBe(2);
-            result.ProcessedArguments.Where(x => x.Item1 == "reference")
-                .Select(x => x.Item2)
-                .Single()
-                .ShouldBe(@"Data1=C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll");
-        }
+    [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\Roslyn\\vbc.exe /noconfig")]
+    [TestCase("/one two/three/vbc.dll /noconfig")]
+    public void TreatsVbcCommandAsSingleArg(string commandLine)
+    {
+        AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
+        result.ProcessedArguments.Count.ShouldBe(2);
+    }
 
-        [TestCase("C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\Roslyn\\vbc.exe /noconfig")]
-        [TestCase("/one two/three/vbc.dll /noconfig")]
-        public void TreatsVbcCommandAsSingleArg(string commandLine)
-        {
-            AnalyzerResult.ProcessedCommandLine result = AnalyzerResult.ProcessCommandLine(commandLine, "vbc.");
-            result.ProcessedArguments.Count.ShouldBe(2);
-        }
+    [Test]
+    public void ParseVbcCommandLineWithMultipleReferences()
+    {
+        // Given
+        string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe")
+                             + @" /reference:""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll"", ""C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\Facades\System.Collections.dll""";
 
-        [Test]
-        public void ParseVbcCommandLineWithMultipleReferences()
-        {
-            // Given
-            string commandLine = Path.Combine("/", "Fizz", "Buzz", "vbc.exe")
-                                 + @" /reference:""C:\Program Files(x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll"", ""C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\Facades\System.Collections.dll""";
+        string projectFilePath = Path.Combine("/", "Code", "Project", "project.vbproj");
+        AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
 
-            string projectFilePath = Path.Combine("/", "Code", "Project", "project.vbproj");
-            AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
+        // When
+        result.ProcessVbcCommandLine(commandLine);
 
-            // When
-            result.ProcessVbcCommandLine(commandLine);
-
-            // Then
-            result.References.Length.ShouldBe(2);
-        }
+        // Then
+        result.References.Length.ShouldBe(2);
     }
 }

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <ProjectReference Include="..\..\src\Buildalyzer\Buildalyzer.csproj" />

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <ProjectReference Include="..\..\src\Buildalyzer\Buildalyzer.csproj" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -12,6 +12,13 @@
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Buildalyzer\Buildalyzer.csproj" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Tests/Construction/PackageReferenceFixture.cs
+++ b/tests/Buildalyzer.Tests/Construction/PackageReferenceFixture.cs
@@ -1,51 +1,49 @@
-﻿using System;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using Buildalyzer.Construction;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Tests.Construction
+namespace Buildalyzer.Tests.Construction;
+
+[TestFixture]
+public class PackageReferenceFixture
 {
-    [TestFixture]
-    public class PackageReferenceFixture
+    [Test]
+    public void PackageReferenceWithIncludeShouldContainName()
     {
-        [Test]
-        public void PackageReferenceWithIncludeShouldContainName()
-        {
-            // Given
-            XElement xml = XElement.Parse(@"<PackageReference Include=""IncludedDependency"" Version=""1.0.0"" />");
+        // Given
+        XElement xml = XElement.Parse(@"<PackageReference Include=""IncludedDependency"" Version=""1.0.0"" />");
 
-            // When
-            PackageReference packageReference = new PackageReference(xml);
+        // When
+        PackageReference packageReference = new PackageReference(xml);
 
-            // Then
-            packageReference.Name.ShouldBe("IncludedDependency");
-        }
+        // Then
+        packageReference.Name.ShouldBe("IncludedDependency");
+    }
 
-        [Test]
-        public void PackageReferenceWithVersionShouldContainVersion()
-        {
-            // Given
-            XElement xml = XElement.Parse(@"<PackageReference Include=""IncludedDependency"" Version=""1.0.0"" />");
+    [Test]
+    public void PackageReferenceWithVersionShouldContainVersion()
+    {
+        // Given
+        XElement xml = XElement.Parse(@"<PackageReference Include=""IncludedDependency"" Version=""1.0.0"" />");
 
-            // When
-            PackageReference packageReference = new PackageReference(xml);
+        // When
+        PackageReference packageReference = new PackageReference(xml);
 
-            // Then
-            packageReference.Version.ShouldBe("1.0.0");
-        }
+        // Then
+        packageReference.Version.ShouldBe("1.0.0");
+    }
 
-        [Test]
-        public void PackageReferenceWithUpgradeShouldContainName()
-        {
-            // Given
-            XElement xml = XElement.Parse(@"<PackageReference Update=""UpdatedDependency"" Version=""1.0.0"" />");
+    [Test]
+    public void PackageReferenceWithUpgradeShouldContainName()
+    {
+        // Given
+        XElement xml = XElement.Parse(@"<PackageReference Update=""UpdatedDependency"" Version=""1.0.0"" />");
 
-            // When
-            PackageReference packageReference = new PackageReference(xml);
+        // When
+        PackageReference packageReference = new PackageReference(xml);
 
-            // Then
-            packageReference.Name.ShouldBe("UpdatedDependency");
-        }
+        // Then
+        packageReference.Name.ShouldBe("UpdatedDependency");
     }
 }

--- a/tests/Buildalyzer.Tests/Environment/DotnetPathResolverFixture.cs
+++ b/tests/Buildalyzer.Tests/Environment/DotnetPathResolverFixture.cs
@@ -1,48 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using Buildalyzer.Environment;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Tests.Environment
+namespace Buildalyzer.Tests.Environment;
+
+[TestFixture]
+public class DotnetPathResolverFixture
 {
-    [TestFixture]
-    public class DotnetPathResolverFixture
+    [TestCase(WindowsNetOutput, @"C:\Program Files\dotnet\sdk\6.0.100\")]
+    [TestCase(WindowsNetCoreOutput, @"C:\Program Files\dotnet\sdk\2.1.300\")]
+    [TestCase(LinuxOutput, "/usr/share/dotnet/sdk/2.1.401/")]
+    public void CanParseBasePath([NotNull] string output, string basePath)
     {
-        [TestCase(WindowsNetOutput, @"C:\Program Files\dotnet\sdk\6.0.100\")]
-        [TestCase(WindowsNetCoreOutput, @"C:\Program Files\dotnet\sdk\2.1.300\")]
-        [TestCase(LinuxOutput, "/usr/share/dotnet/sdk/2.1.401/")]
-        public void CanParseBasePath([NotNull] string output, string basePath)
-        {
-            // Given
-            List<string> lines = output.Split("\n").Select(x => x.Trim('\r')).ToList();
+        // Given
+        List<string> lines = output.Split("\n").Select(x => x.Trim('\r')).ToList();
 
-            // When
-            string result = DotnetPathResolver.ParseBasePath(lines);
+        // When
+        string result = DotnetPathResolver.ParseBasePath(lines);
 
-            // Then
-            result.ShouldBe(basePath);
-        }
+        // Then
+        result.ShouldBe(basePath);
+    }
 
-        [TestCase(WindowsNetOutput, @"C:\Program Files\dotnet\sdk\6.0.100\")]
-        [TestCase(WindowsNetCoreOutput, @"C:\Program Files\dotnet\sdk\2.1.201\")]
-        [TestCase(LinuxOutput, "/usr/share/dotnet/sdk/2.1.201/")]
-        public void CanParseInstalledSdksPath([NotNull] string output, string sdksPath)
-        {
-            // Given
-            List<string> lines = output.Split("\n").Select(x => x.Trim('\r')).ToList();
+    [TestCase(WindowsNetOutput, @"C:\Program Files\dotnet\sdk\6.0.100\")]
+    [TestCase(WindowsNetCoreOutput, @"C:\Program Files\dotnet\sdk\2.1.201\")]
+    [TestCase(LinuxOutput, "/usr/share/dotnet/sdk/2.1.201/")]
+    public void CanParseInstalledSdksPath([NotNull] string output, string sdksPath)
+    {
+        // Given
+        List<string> lines = output.Split("\n").Select(x => x.Trim('\r')).ToList();
 
-            // When
-            string result = DotnetPathResolver.ParseInstalledSdksPath(lines);
+        // When
+        string result = DotnetPathResolver.ParseInstalledSdksPath(lines);
 
-            // Then
-            AnalyzerManager.NormalizePath(result).ShouldBe(AnalyzerManager.NormalizePath(sdksPath));
-        }
+        // Then
+        AnalyzerManager.NormalizePath(result).ShouldBe(AnalyzerManager.NormalizePath(sdksPath));
+    }
 
-        public const string LinuxOutput = @".NET Core SDK (reflecting any global.json):
+    public const string LinuxOutput = @".NET Core SDK (reflecting any global.json):
 Version:   2.1.401
 Commit:    91b1c13032
 
@@ -69,7 +67,7 @@ Host (useful for support):
 To install additional .NET Core runtimes or SDKs:
   https://aka.ms/dotnet-download";
 
-        public const string WindowsNetCoreOutput = @".NET Core SDK (reflecting any global.json):
+    public const string WindowsNetCoreOutput = @".NET Core SDK (reflecting any global.json):
  Version:   2.1.300
  Commit:    adab45bf0c
 
@@ -100,7 +98,7 @@ Host (useful for support):
 To install additional .NET Core runtimes or SDKs:
   https://aka.ms/dotnet-download";
 
-        public const string WindowsNetOutput = @".NET SDK (reflecting any global.json):
+    public const string WindowsNetOutput = @".NET SDK (reflecting any global.json):
  Version:   6.0.100
  Commit:    9e8b04bbff
 
@@ -233,5 +231,4 @@ Host (useful for support):
 
 To install additional .NET runtimes or SDKs:
   https://aka.ms/dotnet-download";
-    }
 }

--- a/tests/Buildalyzer.Tests/Environment/EnvironmentFactoryFixture.cs
+++ b/tests/Buildalyzer.Tests/Environment/EnvironmentFactoryFixture.cs
@@ -1,90 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Buildalyzer.Environment;
+﻿using Buildalyzer.Environment;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Tests.Environment
+namespace Buildalyzer.Tests.Environment;
+
+[TestFixture]
+public class EnvironmentFactoryFixture
 {
-    [TestFixture]
-    public class EnvironmentFactoryFixture
+    // From https://docs.microsoft.com/en-us/dotnet/standard/frameworks
+    // .NET Core/.NET 5 and up
+    [TestCase("netcoreapp1.0", false)]
+    [TestCase("netcoreapp1.1", false)]
+    [TestCase("netcoreapp2.0", false)]
+    [TestCase("netcoreapp2.1", false)]
+    [TestCase("netcoreapp2.2", false)]
+    [TestCase("netcoreapp3.0", false)]
+    [TestCase("netcoreapp3.1", false)]
+    [TestCase("net5", false)] // This isn't an official TFM but we'll check it anyway
+    [TestCase("net5.0", false)]
+    [TestCase("net5.0-android", false)]
+    [TestCase("net5.0-ios", false)]
+    [TestCase("net5.0-macos", false)]
+    [TestCase("net5.0-tvos", false)]
+    [TestCase("net5.0-watchos", false)]
+    [TestCase("net5.0-windows", false)]
+    [TestCase("net6", false)] // This isn't an official TFM but we'll check it anyway
+    [TestCase("net6.0", false)]
+    [TestCase("net6.0-android", false)]
+    [TestCase("net6.0-ios", false)]
+    [TestCase("net6.0-macos", false)]
+    [TestCase("net6.0-tvos", false)]
+    [TestCase("net6.0-watchos", false)]
+    [TestCase("net6.0-windows", false)]
+    [TestCase("netstandard1.0", false)]
+    [TestCase("netstandard1.1", false)]
+    [TestCase("netstandard1.2", false)]
+    [TestCase("netstandard1.3", false)]
+    [TestCase("netstandard1.4", false)]
+    [TestCase("netstandard1.5", false)]
+    [TestCase("netstandard1.6", false)]
+    [TestCase("netstandard2.0", false)]
+    [TestCase("netstandard2.1", false)]
+
+    // .NET Framework
+    [TestCase("net11", true)]
+    [TestCase("net20", true)]
+    [TestCase("net35", true)]
+    [TestCase("net40", true)]
+    [TestCase("net403", true)]
+    [TestCase("net45", true)]
+    [TestCase("net451", true)]
+    [TestCase("net452", true)]
+    [TestCase("net46", true)]
+    [TestCase("net461", true)]
+    [TestCase("net462", true)]
+    [TestCase("net47", true)]
+    [TestCase("net471", true)]
+    [TestCase("net472", true)]
+    [TestCase("net48", true)]
+
+    // Should treat the more exotic TFMs as .NET Framework
+    [TestCase("netcore", true)]
+    [TestCase("netcore45", true)]
+    [TestCase("netcore451", true)]
+    [TestCase("netmf", true)]
+    [TestCase("sl4", true)]
+    [TestCase("sl5", true)]
+    [TestCase("wp", true)]
+    [TestCase("wp7", true)]
+    [TestCase("wp75", true)]
+    [TestCase("wp8", true)]
+    [TestCase("wp81", true)]
+    [TestCase("wpa81", true)]
+    [TestCase("uap", true)]
+    [TestCase("uap10.0", true)]
+    public void IsFrameworkTargetFrameworkForTfm(string targetFramework, bool expected)
     {
-        // From https://docs.microsoft.com/en-us/dotnet/standard/frameworks
-        // .NET Core/.NET 5 and up
-        [TestCase("netcoreapp1.0", false)]
-        [TestCase("netcoreapp1.1", false)]
-        [TestCase("netcoreapp2.0", false)]
-        [TestCase("netcoreapp2.1", false)]
-        [TestCase("netcoreapp2.2", false)]
-        [TestCase("netcoreapp3.0", false)]
-        [TestCase("netcoreapp3.1", false)]
-        [TestCase("net5", false)] // This isn't an official TFM but we'll check it anyway
-        [TestCase("net5.0", false)]
-        [TestCase("net5.0-android", false)]
-        [TestCase("net5.0-ios", false)]
-        [TestCase("net5.0-macos", false)]
-        [TestCase("net5.0-tvos", false)]
-        [TestCase("net5.0-watchos", false)]
-        [TestCase("net5.0-windows", false)]
-        [TestCase("net6", false)] // This isn't an official TFM but we'll check it anyway
-        [TestCase("net6.0", false)]
-        [TestCase("net6.0-android", false)]
-        [TestCase("net6.0-ios", false)]
-        [TestCase("net6.0-macos", false)]
-        [TestCase("net6.0-tvos", false)]
-        [TestCase("net6.0-watchos", false)]
-        [TestCase("net6.0-windows", false)]
-        [TestCase("netstandard1.0", false)]
-        [TestCase("netstandard1.1", false)]
-        [TestCase("netstandard1.2", false)]
-        [TestCase("netstandard1.3", false)]
-        [TestCase("netstandard1.4", false)]
-        [TestCase("netstandard1.5", false)]
-        [TestCase("netstandard1.6", false)]
-        [TestCase("netstandard2.0", false)]
-        [TestCase("netstandard2.1", false)]
+        // Given, When
+        bool result = EnvironmentFactory.IsFrameworkTargetFramework(targetFramework);
 
-        // .NET Framework
-        [TestCase("net11", true)]
-        [TestCase("net20", true)]
-        [TestCase("net35", true)]
-        [TestCase("net40", true)]
-        [TestCase("net403", true)]
-        [TestCase("net45", true)]
-        [TestCase("net451", true)]
-        [TestCase("net452", true)]
-        [TestCase("net46", true)]
-        [TestCase("net461", true)]
-        [TestCase("net462", true)]
-        [TestCase("net47", true)]
-        [TestCase("net471", true)]
-        [TestCase("net472", true)]
-        [TestCase("net48", true)]
-
-        // Should treat the more exotic TFMs as .NET Framework
-        [TestCase("netcore", true)]
-        [TestCase("netcore45", true)]
-        [TestCase("netcore451", true)]
-        [TestCase("netmf", true)]
-        [TestCase("sl4", true)]
-        [TestCase("sl5", true)]
-        [TestCase("wp", true)]
-        [TestCase("wp7", true)]
-        [TestCase("wp75", true)]
-        [TestCase("wp8", true)]
-        [TestCase("wp81", true)]
-        [TestCase("wpa81", true)]
-        [TestCase("uap", true)]
-        [TestCase("uap10.0", true)]
-        public void IsFrameworkTargetFrameworkForTfm(string targetFramework, bool expected)
-        {
-            // Given, When
-            bool result = EnvironmentFactory.IsFrameworkTargetFramework(targetFramework);
-
-            // Then
-            result.ShouldBe(expected);
-        }
+        // Then
+        result.ShouldBe(expected);
     }
 }

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -4,130 +4,185 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text;
-using System.Xml.Linq;
 using Buildalyzer.Environment;
-using Microsoft.Build.Framework;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Tests.Integration
+namespace Buildalyzer.Tests.Integration;
+
+[TestFixture]
+[NonParallelizable]
+public class SimpleProjectsFixture
 {
-    [TestFixture]
-    [NonParallelizable]
-    public class SimpleProjectsFixture
+    // Places the log file in C:/Temp
+    private const bool BinaryLog = false;
+
+    private static readonly EnvironmentPreference[] Preferences =
     {
-        // Places the log file in C:/Temp
-        private const bool BinaryLog = false;
-
-        private static readonly EnvironmentPreference[] Preferences =
-        {
 #if Is_Windows
-            EnvironmentPreference.Framework,
+        EnvironmentPreference.Framework,
 #endif
-            EnvironmentPreference.Core
+        EnvironmentPreference.Core
+    };
+
+    private static readonly string[] ProjectFiles =
+    {
+#if Is_Windows
+        @"LegacyFrameworkProject\LegacyFrameworkProject.csproj",
+        @"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj",
+        @"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj",
+        @"SdkFrameworkProject\SdkFrameworkProject.csproj",
+        @"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj",
+#endif
+        @"SdkNetCore2Project\SdkNetCore2Project.csproj",
+        @"SdkNetCore31Project\SdkNetCore31Project.csproj",
+        @"SdkNet5Project\SdkNet5Project.csproj",
+        @"SdkNet6Project\SdkNet6Project.csproj",
+        @"SdkNet6Exe\SdkNet6Exe.csproj",
+        @"SdkNet6SelfContained\SdkNet6SelfContained.csproj",
+        @"SdkNet6ImplicitUsings\SdkNet6ImplicitUsings.csproj",
+        @"SdkNet7Project\SdkNet7Project.csproj",
+        @"SdkNetCore2ProjectImport\SdkNetCore2ProjectImport.csproj",
+        @"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj",
+        @"SdkNetCore2ProjectWithImportedProps\SdkNetCore2ProjectWithImportedProps.csproj",
+        @"SdkNetCore2ProjectWithAnalyzer\SdkNetCore2ProjectWithAnalyzer.csproj",
+        @"SdkNetStandardProject\SdkNetStandardProject.csproj",
+        @"SdkNetStandardProjectImport\SdkNetStandardProjectImport.csproj",
+        @"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj",
+        @"SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj",
+        @"ResponseFile\ResponseFile.csproj",
+
+        // Using Buildalyzer against Functions projects is currently not supported
+        // the Functions build tooling does some extra compilation and magic that
+        // doesn't work with the default targets Buildlyzer sets (especially for design time builds)
+        // In general, Buildalyzer is not good at analyzing any project that makes extensive use
+        // of custom build tooling and tasks/targets because the behavior and log output is not consistent
+        // See https://github.com/daveaglick/Buildalyzer/issues/210
+        // @"FunctionApp\FunctionApp.csproj",
+    };
+
+    [Test]
+    public void DesignTimeBuildsProject(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
+        [ValueSource(nameof(ProjectFiles))] string projectFile)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+        EnvironmentOptions options = new EnvironmentOptions
+        {
+            Preference = preference
         };
 
-        private static readonly string[] ProjectFiles =
-        {
-#if Is_Windows
-            @"LegacyFrameworkProject\LegacyFrameworkProject.csproj",
-            @"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj",
-            @"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj",
-            @"SdkFrameworkProject\SdkFrameworkProject.csproj",
-            @"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj",
-#endif
-            @"SdkNetCore2Project\SdkNetCore2Project.csproj",
-            @"SdkNetCore31Project\SdkNetCore31Project.csproj",
-            @"SdkNet5Project\SdkNet5Project.csproj",
-            @"SdkNet6Project\SdkNet6Project.csproj",
-            @"SdkNet6Exe\SdkNet6Exe.csproj",
-            @"SdkNet6SelfContained\SdkNet6SelfContained.csproj",
-            @"SdkNet6ImplicitUsings\SdkNet6ImplicitUsings.csproj",
-            @"SdkNet7Project\SdkNet7Project.csproj",
-            @"SdkNetCore2ProjectImport\SdkNetCore2ProjectImport.csproj",
-            @"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj",
-            @"SdkNetCore2ProjectWithImportedProps\SdkNetCore2ProjectWithImportedProps.csproj",
-            @"SdkNetCore2ProjectWithAnalyzer\SdkNetCore2ProjectWithAnalyzer.csproj",
-            @"SdkNetStandardProject\SdkNetStandardProject.csproj",
-            @"SdkNetStandardProjectImport\SdkNetStandardProjectImport.csproj",
-            @"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj",
-            @"SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj",
-            @"ResponseFile\ResponseFile.csproj",
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build(options);
 
-            // Using Buildalyzer against Functions projects is currently not supported
-            // the Functions build tooling does some extra compilation and magic that
-            // doesn't work with the default targets Buildlyzer sets (especially for design time builds)
-            // In general, Buildalyzer is not good at analyzing any project that makes extensive use
-            // of custom build tooling and tasks/targets because the behavior and log output is not consistent
-            // See https://github.com/daveaglick/Buildalyzer/issues/210
-            // @"FunctionApp\FunctionApp.csproj",
+        // Then
+        results.Count.ShouldBeGreaterThan(0, log.ToString());
+        results.OverallSuccess.ShouldBeTrue(log.ToString());
+        results.ShouldAllBe(x => x.Succeeded, log.ToString());
+    }
+
+    [Test]
+    public void BuildsProject(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
+        [ValueSource(nameof(ProjectFiles))] string projectFile)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+        EnvironmentOptions options = new EnvironmentOptions
+        {
+            Preference = preference,
+            DesignTime = false
         };
 
-        [Test]
-        public void DesignTimeBuildsProject(
-            [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-            [ValueSource(nameof(ProjectFiles))] string projectFile)
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build(options);
+
+        // Then
+        results.Count.ShouldBeGreaterThan(0, log.ToString());
+        results.OverallSuccess.ShouldBeTrue(log.ToString());
+        results.ShouldAllBe(x => x.Succeeded, log.ToString());
+    }
+
+    [Test]
+    public void GetsSourceFiles(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
+        [ValueSource(nameof(ProjectFiles))] string projectFile)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+        EnvironmentOptions options = new EnvironmentOptions
         {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
+            Preference = preference
+        };
 
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
+        // When
+        IAnalyzerResults results = analyzer.Build(options);
 
-            // Then
-            results.Count.ShouldBeGreaterThan(0, log.ToString());
-            results.OverallSuccess.ShouldBeTrue(log.ToString());
-            results.ShouldAllBe(x => x.Succeeded, log.ToString());
+        // Then
+        // If this is the multi-targeted project, use the net462 target
+        IReadOnlyList<string> sourceFiles = results.Count == 1 ? results.First().SourceFiles : results["net462"].SourceFiles;
+        sourceFiles.ShouldNotBeNull(log.ToString());
+        new[]
+        {
+            "AssemblyAttributes",
+            analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
+            "AssemblyInfo"
+        }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+    }
+
+    [Test]
+    public void GetsReferences(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
+        [ValueSource(nameof(ProjectFiles))] [NotNull] string projectFile)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+        EnvironmentOptions options = new EnvironmentOptions
+        {
+            Preference = preference
+        };
+
+        // When
+        IAnalyzerResults results = analyzer.Build(options);
+
+        // Then
+        results.ShouldAllBe(x => x.References != null, log.ToString());
+        results.Any(x => x.References.Any(r => r.Contains("mscorlib"))).ShouldBeTrue(log.ToString());
+        if (projectFile.Contains("PackageReference"))
+        {
+            results.Any(x => x.References.Any(r => r.EndsWith("NodaTime.dll"))).ShouldBeTrue(log.ToString());
         }
+    }
 
-        [Test]
-        public void BuildsProject(
-            [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-            [ValueSource(nameof(ProjectFiles))] string projectFile)
+    [Test]
+    public void GetsSourceFilesFromBinaryLog(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
+        [ValueSource(nameof(ProjectFiles))] string projectFile)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+        EnvironmentOptions options = new EnvironmentOptions
         {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference,
-                DesignTime = false
-            };
+            Preference = preference
+        };
+        string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
+        analyzer.AddBinaryLogger(binLogPath);
 
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
-
-            // Then
-            results.Count.ShouldBeGreaterThan(0, log.ToString());
-            results.OverallSuccess.ShouldBeTrue(log.ToString());
-            results.ShouldAllBe(x => x.Succeeded, log.ToString());
-        }
-
-        [Test]
-        public void GetsSourceFiles(
-            [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-            [ValueSource(nameof(ProjectFiles))] string projectFile)
+        try
         {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-
             // When
-            IAnalyzerResults results = analyzer.Build(options);
+            analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
 
             // Then
             // If this is the multi-targeted project, use the net462 target
@@ -135,628 +190,569 @@ namespace Buildalyzer.Tests.Integration
             sourceFiles.ShouldNotBeNull(log.ToString());
             new[]
             {
-                "AssemblyAttributes",
-                analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
-                "AssemblyInfo"
-            }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-        }
-
-        [Test]
-        public void GetsReferences(
-            [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-            [ValueSource(nameof(ProjectFiles))] [NotNull] string projectFile)
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-
-            // When
-            IAnalyzerResults results = analyzer.Build(options);
-
-            // Then
-            results.ShouldAllBe(x => x.References != null, log.ToString());
-            results.Any(x => x.References.Any(r => r.Contains("mscorlib"))).ShouldBeTrue(log.ToString());
-            if (projectFile.Contains("PackageReference"))
-            {
-                results.Any(x => x.References.Any(r => r.EndsWith("NodaTime.dll"))).ShouldBeTrue(log.ToString());
-            }
-        }
-
-        [Test]
-        public void GetsSourceFilesFromBinaryLog(
-            [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
-            [ValueSource(nameof(ProjectFiles))] string projectFile)
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-            string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
-            analyzer.AddBinaryLogger(binLogPath);
-
-            try
-            {
-                // When
-                analyzer.Build(options);
-                IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
-
-                // Then
-                // If this is the multi-targeted project, use the net462 target
-                IReadOnlyList<string> sourceFiles = results.Count == 1 ? results.First().SourceFiles : results["net462"].SourceFiles;
-                sourceFiles.ShouldNotBeNull(log.ToString());
-                new[]
-                {
-                "AssemblyAttributes",
-                analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
-                "AssemblyInfo"
-                }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-            }
-            finally
-            {
-                if (File.Exists(binLogPath))
-                {
-                    File.Delete(binLogPath);
-                }
-            }
-        }
-
-        [Test]
-        [Platform("win")]
-        public void WpfControlLibraryGetsSourceFiles()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"WpfCustomControlLibrary1\WpfCustomControlLibrary1.csproj", log);
-
-            // When
-            IAnalyzerResults results = analyzer.Build();
-
-            // Then
-            IReadOnlyList<string> sourceFiles = results.SingleOrDefault()?.SourceFiles;
-            sourceFiles.ShouldNotBeNull(log.ToString());
-            new[]
-            {
-                "CustomControl1.cs",
-                "AssemblyInfo.cs",
-                "Resources.Designer.cs",
-                "Settings.Designer.cs",
-                "GeneratedInternalTypeHelper.g.cs"
-            }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x)), log.ToString());
-        }
-
-        [Test]
-        public void MultiTargetingBuildAllTargetFrameworksGetsSourceFiles()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
-
-            // When
-            IAnalyzerResults results = analyzer.Build();
-
-            // Then
-            // Multi-targeting projects product an extra result with an empty target framework that holds some MSBuild properties (I.e. the "outer" build)
-            results.Count.ShouldBe(3);
-            results.TargetFrameworks.ShouldBe(new[] { "net462", "netstandard2.0", string.Empty }, ignoreOrder: false, log.ToString());
-            results[string.Empty].SourceFiles.ShouldBeEmpty();
-            new[]
-            {
-                "AssemblyAttributes",
-                "Class1",
-                "AssemblyInfo"
-            }.ShouldBeSubsetOf(results["net462"].SourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-            new[]
-            {
-                "AssemblyAttributes",
-                "Class2",
-                "AssemblyInfo"
-            }.ShouldBeSubsetOf(results["netstandard2.0"].SourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-        }
-
-        [Test]
-        public void SolutionDirShouldEndWithDirectorySeparator()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
-
-            analyzer.SolutionDirectory.ShouldEndWith(Path.DirectorySeparatorChar.ToString());
-        }
-
-        [Test]
-        public void MultiTargetingBuildFrameworkTargetFrameworkGetsSourceFiles()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
-
-            // When
-            IAnalyzerResults results = analyzer.Build("net462");
-
-            // Then
-            IReadOnlyList<string> sourceFiles = results.First(x => x.TargetFramework == "net462").SourceFiles;
-            sourceFiles.ShouldNotBeNull(log.ToString());
-            new[]
-            {
-                "AssemblyAttributes",
-                "Class1",
-                "AssemblyInfo"
-            }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-        }
-
-        [Test]
-        public void MultiTargetingBuildCoreTargetFrameworkGetsSourceFiles()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
-
-            // When
-            IAnalyzerResults results = analyzer.Build("netstandard2.0");
-
-            // Then
-            IReadOnlyList<string> sourceFiles = results.First(x => x.TargetFramework == "netstandard2.0").SourceFiles;
-            sourceFiles.ShouldNotBeNull(log.ToString());
-            new[]
-            {
-                "AssemblyAttributes",
-                "AssemblyInfo",
-                "Class2"
-            }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
-        }
-
-        [Test]
-        public void SdkProjectWithPackageReferenceGetsReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj", log);
-
-            // When
-            IReadOnlyList<string> references = analyzer.Build().First().References;
-
-            // Then
-            references.ShouldNotBeNull(log.ToString());
-            references.ShouldContain(x => x.EndsWith("NodaTime.dll"), log.ToString());
-        }
-
-        [Test]
-        public void SdkProjectWithPackageReferenceGetsPackageReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj", log);
-
-            // When
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> packageReferences = analyzer.Build().First().PackageReferences;
-
-            // Then
-            packageReferences.ShouldNotBeNull(log.ToString());
-            packageReferences.Keys.ShouldContain("NodaTime", log.ToString());
-        }
-
-        [Test]
-        public void SdkProjectWithProjectReferenceGetsReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
-
-            // When
-            IEnumerable<string> references = analyzer.Build().First().ProjectReferences;
-
-            // Then
-            references.ShouldNotBeNull(log.ToString());
-            references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
-            references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
-        }
-
-        [Test]
-        public void SdkProjectWithDefineContstantsGetsPreprocessorSymbols()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj", log);
-
-            // When
-            IEnumerable<string> preprocessorSymbols = analyzer.Build().First().PreprocessorSymbols;
-
-            // Then
-            preprocessorSymbols.ShouldNotBeNull(log.ToString());
-            preprocessorSymbols.ShouldContain("DEF2", log.ToString());
-            preprocessorSymbols.ShouldContain("NETSTANDARD2_0", log.ToString());
-
-            // If this test runs on .NET 5 or greater, the NETSTANDARD2_0_OR_GREATER preprocessor symbol should be added. Can't test on lower SDK versions
-
-#if NETSTANDARD2_0_OR_GREATER
-            preprocessorSymbols.ShouldContain("NETSTANDARD2_0_OR_GREATER", log.ToString());
-#endif
-        }
-
-        [Test]
-        [Platform("win")]
-        public void LegacyFrameworkProjectWithPackageReferenceGetsReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", log);
-
-            // When
-            IReadOnlyList<string> references = analyzer.Build().First().References;
-
-            // Then
-            references.ShouldNotBeNull(log.ToString());
-            references.ShouldContain(x => x.EndsWith("NodaTime.dll"), log.ToString());
-        }
-
-        [Test]
-        public void LegacyFrameworkProjectWithPackageReferenceGetsPackageReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", log);
-
-            // When
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> packageReferences = analyzer.Build().First().PackageReferences;
-
-            // Then
-            packageReferences.ShouldNotBeNull(log.ToString());
-            packageReferences.Keys.ShouldContain("NodaTime", log.ToString());
-        }
-
-        [Test]
-        public void LegacyFrameworkProjectWithProjectReferenceGetsReferences()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj", log);
-
-            // When
-            IEnumerable<string> references = analyzer.Build().First().ProjectReferences;
-
-            // Then
-            references.ShouldNotBeNull(log.ToString());
-            references.ShouldContain(x => x.EndsWith("LegacyFrameworkProject.csproj"), log.ToString());
-            references.ShouldContain(x => x.EndsWith("LegacyFrameworkProjectWithPackageReference.csproj"), log.ToString());
-        }
-
-        [Test]
-        public void GetsProjectsInSolution()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-
-            // When
-            AnalyzerManager manager = new AnalyzerManager(
-                GetProjectPath("TestProjects.sln"),
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                });
-
-            // Then
-            ProjectFiles.Select(x => GetProjectPath(x)).ShouldBeSubsetOf(manager.Projects.Keys, log.ToString());
-        }
-
-        [Test]
-        public void FiltersProjectsInSolution()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-
-            // When
-            AnalyzerManager manager = new AnalyzerManager(
-                GetProjectPath("TestProjects.sln"),
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log,
-                    ProjectFilter = x => x.AbsolutePath.Contains("Core")
-                });
-
-            // Then
-            ProjectFiles.Select(x => GetProjectPath(x)).Where(x => x.Contains("Core")).ShouldBe(manager.Projects.Keys, true, log.ToString());
-        }
-
-        [Test]
-        public void IgnoreSolutionItemsThatAreNotProjects()
-        {
-            // Given / When
-            AnalyzerManager manager = new AnalyzerManager(GetProjectPath("TestProjects.sln"));
-
-            // Then
-            manager.Projects.Any(x => x.Value.ProjectFile.Path.Contains("TestEmptySolutionFolder")).ShouldBeFalse();
-        }
-
-        [Test]
-        public void GetsProjectGuidFromSolution([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
-        {
-            // Given
-            AnalyzerManager manager = new AnalyzerManager(
-                GetProjectPath("TestProjects.sln"));
-            IProjectAnalyzer analyzer = manager.Projects.First(x => x.Key.EndsWith("SdkNetStandardProject.csproj")).Value;
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-
-            // When
-            DeleteProjectDirectory(analyzer.ProjectFile.Path, "obj");
-            DeleteProjectDirectory(analyzer.ProjectFile.Path, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
-
-            // Then
-            results.First().ProjectGuid.ToString().ShouldBe("016713d9-b665-4272-9980-148801a9b88f");
-        }
-
-        [Test]
-        public void GetsProjectGuidFromProject([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
-        {
-            // Given
-            const string projectFile = @"SdkNetCore2Project\SdkNetCore2Project.csproj";
-            IProjectAnalyzer analyzer = new AnalyzerManager()
-                .GetProject(GetProjectPath(projectFile));
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
-
-            // Then
-            // The generated GUIDs are based on subpath and can also change between MSBuild versions,
-            // so this may need to be updated periodically
-            results.First().ProjectGuid.ToString().ShouldBe("1ff50b40-c27b-5cea-b265-29c5436a8a7b");
-        }
-
-        [Test]
-        public void BuildsProjectWithoutLogger([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
-        {
-            // Given
-            const string projectFile = @"SdkNetCore2Project\SdkNetCore2Project.csproj";
-            IProjectAnalyzer analyzer = new AnalyzerManager()
-                .GetProject(GetProjectPath(projectFile));
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = preference
-            };
-
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
-
-            // Then
-            results.Count.ShouldBeGreaterThan(0);
-            results.OverallSuccess.ShouldBeTrue();
-            results.ShouldAllBe(x => x.Succeeded);
-        }
-
-        [Test]
-        public void BuildsFSharpProject()
-        {
-            // Given
-            const string projectFile = @"FSharpProject\FSharpProject.fsproj";
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build();
-
-            // Then
-            results.Count.ShouldBeGreaterThan(0, log.ToString());
-            results.First().SourceFiles.ShouldNotBeNull();
-            results.OverallSuccess.ShouldBeTrue(log.ToString());
-            results.ShouldAllBe(x => x.Succeeded, log.ToString());
-        }
-
-        [Test]
-        public void BuildsVisualBasicProject()
-        {
-            // Given
-            const string projectFile = @"VisualBasicProject\VisualBasicNetConsoleApp.vbproj";
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-
-            // When
-            DeleteProjectDirectory(projectFile, "obj");
-            DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build();
-
-            // Then
-            results.Count.ShouldBeGreaterThan(0, log.ToString());
-            results.OverallSuccess.ShouldBeTrue(log.ToString());
-            results.ShouldAllBe(x => x.Succeeded, log.ToString());
-
-            IAnalyzerResult result = results.First();
-            result.PackageReferences.Count.ShouldBeGreaterThan(0);
-            result.PackageReferences.ShouldContain(x => x.Key == "BouncyCastle.NetCore");
-            result.SourceFiles.Length.ShouldBeGreaterThan(0);
-            result.SourceFiles.ShouldContain(x => x.Contains("Program.vb"));
-            result.References.Length.ShouldBeGreaterThan(0);
-            result.References.ShouldContain(x => x.Contains("BouncyCastle.Crypto.dll"));
-        }
-
-        [Test]
-        public void BuildsLotsOfProjects()
-        {
-            // Given
-            StringWriter log = new StringWriter();
-            AnalyzerManager manager = new AnalyzerManager(
-                GetProjectPath(@"LotsOfProjects\LotsOfProjects.sln"),
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                });
-            List<IProjectAnalyzer> projects = manager.Projects.Values.ToList();
-
-            // When
-            List<IAnalyzerResults> analyzerResults = projects
-                .AsParallel()
-                .Select(x => x.Build())
-                .ToList();
-
-            // Then
-            analyzerResults.Count.ShouldBe(50);
-        }
-
-        // To produce different versions, create a global.json and then run `dotnet clean` and `dotnet build -bl:SdkNetCore31Project-vX.binlog` from the source project folder
-        [TestCase("SdkNetCore31Project-v9.binlog", 9)]
-        [TestCase("SdkNetCore31Project-v14.binlog", 14)]
-        public void GetsSourceFilesFromBinLogFile(string path, int expectedVersion)
-        {
-            // Verify this is the expected version
-            path = Path.GetFullPath(
-                Path.Combine(
-                    Path.GetDirectoryName(typeof(SimpleProjectsFixture).Assembly.Location),
-                    "..",
-                    "..",
-                    "..",
-                    "..",
-                    "binlogs",
-                    path))
-                .Replace('\\', Path.DirectorySeparatorChar);
-            EnvironmentOptions options = new EnvironmentOptions();
-            using (Stream stream = File.OpenRead(path))
-            {
-                using (GZipStream gzip = new GZipStream(stream, CompressionMode.Decompress))
-                {
-                    using (BinaryReader reader = new BinaryReader(gzip))
-                    {
-                        reader.ReadInt32().ShouldBe(expectedVersion);
-                    }
-                }
-            }
-
-            // Given
-            StringWriter log = new StringWriter();
-            AnalyzerManager analyzerManager = new AnalyzerManager(
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                });
-
-            // When
-            IAnalyzerResults analyzerResults = analyzerManager.Analyze(path);
-            IReadOnlyList<string> sourceFiles = analyzerResults.First().SourceFiles;
-
-            // Then
-            sourceFiles.ShouldNotBeNull(log.ToString());
-            new[]
-            {
             "AssemblyAttributes",
-            "Class1",
+            analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
             "AssemblyInfo"
             }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
         }
-
-        [Test]
-        public static void DuplicateProjectReferences()
+        finally
         {
-            // Given
-            StringWriter log = new StringWriter();
-            AnalyzerManager manager = new AnalyzerManager(
-                GetProjectPath(@"DuplicateProjectReferences\MainProject\MainProject.sln"),
-                new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                });
-            List<IProjectAnalyzer> projects = manager.Projects.Values.ToList();
-
-            // When
-            List<IAnalyzerResults> analyzerResults = projects
-                .AsParallel()
-                .Select(x => x.Build())
-                .ToList();
-
-            // Then
-            analyzerResults.ForEach(v =>
+            if (File.Exists(binLogPath))
             {
-                IAnalyzerResult result = v.Results.FirstOrDefault();
-                result.ProjectReferences.Count().ShouldBeLessThanOrEqualTo(1);
+                File.Delete(binLogPath);
+            }
+        }
+    }
+
+    [Test]
+    [Platform("win")]
+    public void WpfControlLibraryGetsSourceFiles()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"WpfCustomControlLibrary1\WpfCustomControlLibrary1.csproj", log);
+
+        // When
+        IAnalyzerResults results = analyzer.Build();
+
+        // Then
+        IReadOnlyList<string> sourceFiles = results.SingleOrDefault()?.SourceFiles;
+        sourceFiles.ShouldNotBeNull(log.ToString());
+        new[]
+        {
+            "CustomControl1.cs",
+            "AssemblyInfo.cs",
+            "Resources.Designer.cs",
+            "Settings.Designer.cs",
+            "GeneratedInternalTypeHelper.g.cs"
+        }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x)), log.ToString());
+    }
+
+    [Test]
+    public void MultiTargetingBuildAllTargetFrameworksGetsSourceFiles()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
+
+        // When
+        IAnalyzerResults results = analyzer.Build();
+
+        // Then
+        // Multi-targeting projects product an extra result with an empty target framework that holds some MSBuild properties (I.e. the "outer" build)
+        results.Count.ShouldBe(3);
+        results.TargetFrameworks.ShouldBe(new[] { "net462", "netstandard2.0", string.Empty }, ignoreOrder: false, log.ToString());
+        results[string.Empty].SourceFiles.ShouldBeEmpty();
+        new[]
+        {
+            "AssemblyAttributes",
+            "Class1",
+            "AssemblyInfo"
+        }.ShouldBeSubsetOf(results["net462"].SourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+        new[]
+        {
+            "AssemblyAttributes",
+            "Class2",
+            "AssemblyInfo"
+        }.ShouldBeSubsetOf(results["netstandard2.0"].SourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+    }
+
+    [Test]
+    public void SolutionDirShouldEndWithDirectorySeparator()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
+
+        analyzer.SolutionDirectory.ShouldEndWith(Path.DirectorySeparatorChar.ToString());
+    }
+
+    [Test]
+    public void MultiTargetingBuildFrameworkTargetFrameworkGetsSourceFiles()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
+
+        // When
+        IAnalyzerResults results = analyzer.Build("net462");
+
+        // Then
+        IReadOnlyList<string> sourceFiles = results.First(x => x.TargetFramework == "net462").SourceFiles;
+        sourceFiles.ShouldNotBeNull(log.ToString());
+        new[]
+        {
+            "AssemblyAttributes",
+            "Class1",
+            "AssemblyInfo"
+        }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+    }
+
+    [Test]
+    public void MultiTargetingBuildCoreTargetFrameworkGetsSourceFiles()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
+
+        // When
+        IAnalyzerResults results = analyzer.Build("netstandard2.0");
+
+        // Then
+        IReadOnlyList<string> sourceFiles = results.First(x => x.TargetFramework == "netstandard2.0").SourceFiles;
+        sourceFiles.ShouldNotBeNull(log.ToString());
+        new[]
+        {
+            "AssemblyAttributes",
+            "AssemblyInfo",
+            "Class2"
+        }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+    }
+
+    [Test]
+    public void SdkProjectWithPackageReferenceGetsReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj", log);
+
+        // When
+        IReadOnlyList<string> references = analyzer.Build().First().References;
+
+        // Then
+        references.ShouldNotBeNull(log.ToString());
+        references.ShouldContain(x => x.EndsWith("NodaTime.dll"), log.ToString());
+    }
+
+    [Test]
+    public void SdkProjectWithPackageReferenceGetsPackageReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithPackageReference\SdkNetStandardProjectWithPackageReference.csproj", log);
+
+        // When
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> packageReferences = analyzer.Build().First().PackageReferences;
+
+        // Then
+        packageReferences.ShouldNotBeNull(log.ToString());
+        packageReferences.Keys.ShouldContain("NodaTime", log.ToString());
+    }
+
+    [Test]
+    public void SdkProjectWithProjectReferenceGetsReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
+
+        // When
+        IEnumerable<string> references = analyzer.Build().First().ProjectReferences;
+
+        // Then
+        references.ShouldNotBeNull(log.ToString());
+        references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
+        references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
+    }
+
+    [Test]
+    public void SdkProjectWithDefineContstantsGetsPreprocessorSymbols()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj", log);
+
+        // When
+        IEnumerable<string> preprocessorSymbols = analyzer.Build().First().PreprocessorSymbols;
+
+        // Then
+        preprocessorSymbols.ShouldNotBeNull(log.ToString());
+        preprocessorSymbols.ShouldContain("DEF2", log.ToString());
+        preprocessorSymbols.ShouldContain("NETSTANDARD2_0", log.ToString());
+
+        // If this test runs on .NET 5 or greater, the NETSTANDARD2_0_OR_GREATER preprocessor symbol should be added. Can't test on lower SDK versions
+
+#if NETSTANDARD2_0_OR_GREATER
+        preprocessorSymbols.ShouldContain("NETSTANDARD2_0_OR_GREATER", log.ToString());
+#endif
+    }
+
+    [Test]
+    [Platform("win")]
+    public void LegacyFrameworkProjectWithPackageReferenceGetsReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", log);
+
+        // When
+        IReadOnlyList<string> references = analyzer.Build().First().References;
+
+        // Then
+        references.ShouldNotBeNull(log.ToString());
+        references.ShouldContain(x => x.EndsWith("NodaTime.dll"), log.ToString());
+    }
+
+    [Test]
+    public void LegacyFrameworkProjectWithPackageReferenceGetsPackageReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", log);
+
+        // When
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> packageReferences = analyzer.Build().First().PackageReferences;
+
+        // Then
+        packageReferences.ShouldNotBeNull(log.ToString());
+        packageReferences.Keys.ShouldContain("NodaTime", log.ToString());
+    }
+
+    [Test]
+    public void LegacyFrameworkProjectWithProjectReferenceGetsReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj", log);
+
+        // When
+        IEnumerable<string> references = analyzer.Build().First().ProjectReferences;
+
+        // Then
+        references.ShouldNotBeNull(log.ToString());
+        references.ShouldContain(x => x.EndsWith("LegacyFrameworkProject.csproj"), log.ToString());
+        references.ShouldContain(x => x.EndsWith("LegacyFrameworkProjectWithPackageReference.csproj"), log.ToString());
+    }
+
+    [Test]
+    public void GetsProjectsInSolution()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+
+        // When
+        AnalyzerManager manager = new AnalyzerManager(
+            GetProjectPath("TestProjects.sln"),
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log
             });
-        }
 
-        [Test]
-        public void GetsAdditionalCscFiles()
+        // Then
+        ProjectFiles.Select(x => GetProjectPath(x)).ShouldBeSubsetOf(manager.Projects.Keys, log.ToString());
+    }
+
+    [Test]
+    public void FiltersProjectsInSolution()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+
+        // When
+        AnalyzerManager manager = new AnalyzerManager(
+            GetProjectPath("TestProjects.sln"),
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log,
+                ProjectFilter = x => x.AbsolutePath.Contains("Core")
+            });
+
+        // Then
+        ProjectFiles.Select(x => GetProjectPath(x)).Where(x => x.Contains("Core")).ShouldBe(manager.Projects.Keys, true, log.ToString());
+    }
+
+    [Test]
+    public void IgnoreSolutionItemsThatAreNotProjects()
+    {
+        // Given / When
+        AnalyzerManager manager = new AnalyzerManager(GetProjectPath("TestProjects.sln"));
+
+        // Then
+        manager.Projects.Any(x => x.Value.ProjectFile.Path.Contains("TestEmptySolutionFolder")).ShouldBeFalse();
+    }
+
+    [Test]
+    public void GetsProjectGuidFromSolution([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        AnalyzerManager manager = new AnalyzerManager(
+            GetProjectPath("TestProjects.sln"));
+        IProjectAnalyzer analyzer = manager.Projects.First(x => x.Key.EndsWith("SdkNetStandardProject.csproj")).Value;
+        EnvironmentOptions options = new EnvironmentOptions
         {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"RazorClassLibraryTest\RazorClassLibraryTest.csproj", log);
+            Preference = preference
+        };
 
-            // When
-            IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+        // When
+        DeleteProjectDirectory(analyzer.ProjectFile.Path, "obj");
+        DeleteProjectDirectory(analyzer.ProjectFile.Path, "bin");
+        IAnalyzerResults results = analyzer.Build(options);
 
-            // Then
-            additionalFiles.ShouldBe(new[] { "_Imports.razor", "Component1.razor" }, log.ToString());
-        }
+        // Then
+        results.First().ProjectGuid.ToString().ShouldBe("016713d9-b665-4272-9980-148801a9b88f");
+    }
 
-        [Test]
-        public void GetsAdditionalFile()
+    [Test]
+    public void GetsProjectGuidFromProject([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        const string projectFile = @"SdkNetCore2Project\SdkNetCore2Project.csproj";
+        IProjectAnalyzer analyzer = new AnalyzerManager()
+            .GetProject(GetProjectPath(projectFile));
+        EnvironmentOptions options = new EnvironmentOptions
         {
-            // Given
-            StringWriter log = new StringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
+            Preference = preference
+        };
 
-            // When
-            IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build(options);
 
-            // Then
-            additionalFiles.ShouldBe(new[] { "message.txt" }, log.ToString());
-        }
+        // Then
+        // The generated GUIDs are based on subpath and can also change between MSBuild versions,
+        // so this may need to be updated periodically
+        results.First().ProjectGuid.ToString().ShouldBe("1ff50b40-c27b-5cea-b265-29c5436a8a7b");
+    }
 
-        private static IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log)
+    [Test]
+    public void BuildsProjectWithoutLogger([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        const string projectFile = @"SdkNetCore2Project\SdkNetCore2Project.csproj";
+        IProjectAnalyzer analyzer = new AnalyzerManager()
+            .GetProject(GetProjectPath(projectFile));
+        EnvironmentOptions options = new EnvironmentOptions
         {
-            IProjectAnalyzer analyzer = new AnalyzerManager(
-                new AnalyzerManagerOptions
+            Preference = preference
+        };
+
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build(options);
+
+        // Then
+        results.Count.ShouldBeGreaterThan(0);
+        results.OverallSuccess.ShouldBeTrue();
+        results.ShouldAllBe(x => x.Succeeded);
+    }
+
+    [Test]
+    public void BuildsFSharpProject()
+    {
+        // Given
+        const string projectFile = @"FSharpProject\FSharpProject.fsproj";
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build();
+
+        // Then
+        results.Count.ShouldBeGreaterThan(0, log.ToString());
+        results.First().SourceFiles.ShouldNotBeNull();
+        results.OverallSuccess.ShouldBeTrue(log.ToString());
+        results.ShouldAllBe(x => x.Succeeded, log.ToString());
+    }
+
+    [Test]
+    public void BuildsVisualBasicProject()
+    {
+        // Given
+        const string projectFile = @"VisualBasicProject\VisualBasicNetConsoleApp.vbproj";
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+
+        // When
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build();
+
+        // Then
+        results.Count.ShouldBeGreaterThan(0, log.ToString());
+        results.OverallSuccess.ShouldBeTrue(log.ToString());
+        results.ShouldAllBe(x => x.Succeeded, log.ToString());
+
+        IAnalyzerResult result = results.First();
+        result.PackageReferences.Count.ShouldBeGreaterThan(0);
+        result.PackageReferences.ShouldContain(x => x.Key == "BouncyCastle.NetCore");
+        result.SourceFiles.Length.ShouldBeGreaterThan(0);
+        result.SourceFiles.ShouldContain(x => x.Contains("Program.vb"));
+        result.References.Length.ShouldBeGreaterThan(0);
+        result.References.ShouldContain(x => x.Contains("BouncyCastle.Crypto.dll"));
+    }
+
+    [Test]
+    public void BuildsLotsOfProjects()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        AnalyzerManager manager = new AnalyzerManager(
+            GetProjectPath(@"LotsOfProjects\LotsOfProjects.sln"),
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log
+            });
+        List<IProjectAnalyzer> projects = manager.Projects.Values.ToList();
+
+        // When
+        List<IAnalyzerResults> analyzerResults = projects
+            .AsParallel()
+            .Select(x => x.Build())
+            .ToList();
+
+        // Then
+        analyzerResults.Count.ShouldBe(50);
+    }
+
+    // To produce different versions, create a global.json and then run `dotnet clean` and `dotnet build -bl:SdkNetCore31Project-vX.binlog` from the source project folder
+    [TestCase("SdkNetCore31Project-v9.binlog", 9)]
+    [TestCase("SdkNetCore31Project-v14.binlog", 14)]
+    public void GetsSourceFilesFromBinLogFile(string path, int expectedVersion)
+    {
+        // Verify this is the expected version
+        path = Path.GetFullPath(
+            Path.Combine(
+                Path.GetDirectoryName(typeof(SimpleProjectsFixture).Assembly.Location),
+                "..",
+                "..",
+                "..",
+                "..",
+                "binlogs",
+                path))
+            .Replace('\\', Path.DirectorySeparatorChar);
+        EnvironmentOptions options = new EnvironmentOptions();
+        using (Stream stream = File.OpenRead(path))
+        {
+            using (GZipStream gzip = new GZipStream(stream, CompressionMode.Decompress))
+            {
+                using (BinaryReader reader = new BinaryReader(gzip))
                 {
-                    LogWriter = log
-                })
-                .GetProject(GetProjectPath(projectFile));
+                    reader.ReadInt32().ShouldBe(expectedVersion);
+                }
+            }
+        }
+
+        // Given
+        StringWriter log = new StringWriter();
+        AnalyzerManager analyzerManager = new AnalyzerManager(
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log
+            });
+
+        // When
+        IAnalyzerResults analyzerResults = analyzerManager.Analyze(path);
+        IReadOnlyList<string> sourceFiles = analyzerResults.First().SourceFiles;
+
+        // Then
+        sourceFiles.ShouldNotBeNull(log.ToString());
+        new[]
+        {
+        "AssemblyAttributes",
+        "Class1",
+        "AssemblyInfo"
+        }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
+    }
+
+    [Test]
+    public static void DuplicateProjectReferences()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        AnalyzerManager manager = new AnalyzerManager(
+            GetProjectPath(@"DuplicateProjectReferences\MainProject\MainProject.sln"),
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log
+            });
+        List<IProjectAnalyzer> projects = manager.Projects.Values.ToList();
+
+        // When
+        List<IAnalyzerResults> analyzerResults = projects
+            .AsParallel()
+            .Select(x => x.Build())
+            .ToList();
+
+        // Then
+        analyzerResults.ForEach(v =>
+        {
+            IAnalyzerResult result = v.Results.FirstOrDefault();
+            result.ProjectReferences.Count().ShouldBeLessThanOrEqualTo(1);
+        });
+    }
+
+    [Test]
+    public void GetsAdditionalCscFiles()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"RazorClassLibraryTest\RazorClassLibraryTest.csproj", log);
+
+        // When
+        IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+
+        // Then
+        additionalFiles.ShouldBe(new[] { "_Imports.razor", "Component1.razor" }, log.ToString());
+    }
+
+    [Test]
+    public void GetsAdditionalFile()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
+
+        // When
+        IEnumerable<string> additionalFiles = analyzer.Build().First().AdditionalFiles;
+
+        // Then
+        additionalFiles.ShouldBe(new[] { "message.txt" }, log.ToString());
+    }
+
+    private static IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log)
+    {
+        IProjectAnalyzer analyzer = new AnalyzerManager(
+            new AnalyzerManagerOptions
+            {
+                LogWriter = log
+            })
+            .GetProject(GetProjectPath(projectFile));
 
 #pragma warning disable 0162
-            if (BinaryLog)
-            {
-                analyzer.AddBinaryLogger(Path.Combine(@"C:\Temp\", Path.ChangeExtension(Path.GetFileName(projectFile), ".core.binlog")));
-            }
+        if (BinaryLog)
+        {
+            analyzer.AddBinaryLogger(Path.Combine(@"C:\Temp\", Path.ChangeExtension(Path.GetFileName(projectFile), ".core.binlog")));
+        }
 #pragma warning restore 0162
 
-            return analyzer;
-        }
+        return analyzer;
+    }
 
-        private static string GetProjectPath(string file)
+    private static string GetProjectPath(string file)
+    {
+        string path = Path.GetFullPath(
+            Path.Combine(
+                Path.GetDirectoryName(typeof(SimpleProjectsFixture).Assembly.Location),
+                "..",
+                "..",
+                "..",
+                "..",
+                "projects",
+                file));
+
+        return path.Replace('\\', Path.DirectorySeparatorChar);
+    }
+
+    private static void DeleteProjectDirectory(string projectFile, string directory)
+    {
+        string path = Path.Combine(Path.GetDirectoryName(GetProjectPath(projectFile)), directory);
+        if (Directory.Exists(path))
         {
-            string path = Path.GetFullPath(
-                Path.Combine(
-                    Path.GetDirectoryName(typeof(SimpleProjectsFixture).Assembly.Location),
-                    "..",
-                    "..",
-                    "..",
-                    "..",
-                    "projects",
-                    file));
-
-            return path.Replace('\\', Path.DirectorySeparatorChar);
-        }
-
-        private static void DeleteProjectDirectory(string projectFile, string directory)
-        {
-            string path = Path.Combine(Path.GetDirectoryName(GetProjectPath(projectFile)), directory);
-            if (Directory.Exists(path))
-            {
-                Directory.Delete(path, true);
-            }
+            Directory.Delete(path, true);
         }
     }
 }

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -11,6 +11,13 @@
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Buildalyzer.Workspaces\Buildalyzer.Workspaces.csproj" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <ProjectReference Include="..\..\src\Buildalyzer.Workspaces\Buildalyzer.Workspaces.csproj" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <ProjectReference Include="..\..\src\Buildalyzer.Workspaces\Buildalyzer.Workspaces.csproj" />

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -23,7 +23,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         workspace.CurrentSolution.Projects.First().Documents.ShouldContain(x => x.Name == "Class1.cs", log.ToString());
     }
 
@@ -40,7 +40,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         workspace.CurrentSolution.FilePath.ShouldBe(solutionPath);
         workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "LegacyFrameworkProject");
         workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkFrameworkProject");
@@ -59,7 +59,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         compilation.GetSymbolsWithName(x => x == "Class1").ShouldNotBeEmpty(log.ToString());
     }
 
@@ -76,7 +76,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         compilationOptions.OutputKind.ShouldBe(OutputKind.DynamicallyLinkedLibrary, log.ToString());
     }
 
@@ -93,7 +93,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
     }
 
@@ -110,7 +110,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
     }
 
@@ -127,7 +127,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         compilation.GetSymbolsWithName(x => x == "Class1").ShouldBeEmpty(log.ToString());
         compilation.GetSymbolsWithName(x => x == "Class2").ShouldNotBeEmpty(log.ToString());
     }
@@ -145,7 +145,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         project.AnalyzerReferences.ShouldContain(reference => reference.Display == "Microsoft.CodeQuality.Analyzers");
     }
 
@@ -162,7 +162,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         project.AdditionalDocuments.Select(d => d.Name).ShouldBe(new[] { "message.txt" });
     }
 
@@ -197,7 +197,7 @@ public class ProjectAnalyzerExtensionsFixture
 
         // Then
         string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed", logged);
+        logged.ShouldNotContain("Workspace failed");
         project.ShouldNotBeNull();
         project.Documents.ShouldNotBeEmpty();
     }

--- a/tests/Buildalyzer.Workspaces.Tests/SafeStringWriter.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/SafeStringWriter.cs
@@ -1,46 +1,41 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
-namespace Buildalyzer.Workspaces.Tests
+namespace Buildalyzer.Workspaces.Tests;
+
+// See https://github.com/xunit/xunit/issues/164
+internal class SafeStringWriter : StringWriter
 {
-    // See https://github.com/xunit/xunit/issues/164
-    internal class SafeStringWriter : StringWriter
+    private readonly object _lock = new object();
+
+    public override void Write(char value)
     {
-        private readonly object _lock = new object();
-
-        public override void Write(char value)
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                base.Write(value);
-            }
+            base.Write(value);
         }
+    }
 
-        public override void Write(char[] buffer, int index, int count)
+    public override void Write(char[] buffer, int index, int count)
+    {
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                base.Write(buffer, index, count);
-            }
+            base.Write(buffer, index, count);
         }
+    }
 
-        public override void Write(string value)
+    public override void Write(string value)
+    {
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                base.Write(value);
-            }
+            base.Write(value);
         }
+    }
 
-        public override string ToString()
+    public override string ToString()
+    {
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                return base.ToString();
-            }
+            return base.ToString();
         }
     }
 }


### PR DESCRIPTION
As suggested in #249 , I took the liberty to update the target frameworks to .NET 8 (and for the published packages, .NET 6 is the secondary target), and use C# 12.

While at it, I updated the analyzer and Unit Test dependencies.