### PR TITLE
Use NuGetFramework to deal with TargetFramework logic

### DIFF
--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Build" Version="17.0.1" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.1" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.815" Aliases="StructuredLogger" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using Buildalyzer.Construction;
 using Microsoft.Build.Utilities;
 using Microsoft.Extensions.Logging;
+using NuGet.Frameworks;
 
 namespace Buildalyzer.Environment;
 
@@ -198,11 +199,10 @@ public class EnvironmentFactory
 
     // Internal for testing
     // Because the .NET Core/.NET 5 TFMs are better defined, we just check if this is one of them and then negate
-    internal static bool IsFrameworkTargetFramework(string targetFramework) =>
-        !(targetFramework.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase)
-        || targetFramework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase)
-        || (targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
-            && targetFramework.Length > 3
-            && int.TryParse(new string(new[] { targetFramework[3] }), out int version)
-            && version >= 5));
+    internal static bool IsFrameworkTargetFramework(string targetFramework)
+    {
+        NuGetFramework tfm = NuGetFramework.Parse(targetFramework);
+        return tfm.Framework != ".NETStandard"
+            && tfm.Framework != ".NETCoreApp";
+    }
 }


### PR DESCRIPTION
`NuGetFramework` represents the target framework and its domain concerns. Thanks for the suggestion @rouke-broersma !