### PR TITLE
Drop `EmptyDisposable`

### DIFF
--- a/src/Buildalyzer/EmptyDisposable.cs
+++ b/src/Buildalyzer/EmptyDisposable.cs
@@ -2,6 +2,7 @@
 
 namespace Buildalyzer;
 
+[Obsolete("Will be dropped in the next major version.")]
 public class EmptyDisposable : IDisposable
 {
     public void Dispose()

--- a/src/Buildalyzer/Logging/TextWriterLogger.cs
+++ b/src/Buildalyzer/Logging/TextWriterLogger.cs
@@ -4,19 +4,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Buildalyzer.Logging;
 
-internal class TextWriterLogger : ILogger
+/// <summary>Implements <see cref="ILogger"/> using a <see cref="TextWriter"/>.</summary>
+internal sealed class TextWriterLogger(TextWriter textWriter) : ILogger
 {
-    private readonly TextWriter _textWriter;
+    private readonly TextWriter _textWriter = textWriter;
 
-    public TextWriterLogger(TextWriter textWriter)
-    {
-        _textWriter = textWriter;
-    }
-
+    /// <inheritdoc />
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
         _textWriter.Write(formatter(state, exception));
 
+    /// <inheritdoc />
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable BeginScope<TState>(TState state) => new EmptyDisposable();
+    /// <inheritdoc />
+    public IDisposable BeginScope<TState>(TState state) => new Scope();
+
+    private sealed class Scope : IDisposable
+    {
+        public void Dispose()
+        {
+            // Nothing to dispose.
+        }
+    }
 }


### PR DESCRIPTION
Providing `EmptyDisposable` as part of the public API should not be part of Buildalyzer. I've decorated it as `[Obsolete]` and created a private alternative for the place where it was actually used.