### PR TITLE
Define the MS Build design time as read-only data structure

### DIFF
--- a/src/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/Buildalyzer/Environment/MsBuildProperties.cs
@@ -1,4 +1,7 @@
-﻿namespace Buildalyzer.Environment;
+﻿using System;
+using System.Collections.Generic;
+
+namespace Buildalyzer.Environment;
 
 public static class MsBuildProperties
 {
@@ -12,8 +15,11 @@ public static class MsBuildProperties
     public const string TargetFramework = nameof(TargetFramework);
 
     // Design-time Build
-    public const string DesignTimeBuild = nameof(DesignTimeBuild); // New project system (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
-    public const string BuildingProject = nameof(BuildingProject); // Legacy (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
+    // New project system (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
+    public const string DesignTimeBuild = nameof(DesignTimeBuild);
+
+    // Legacy (https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build)
+    public const string BuildingProject = nameof(BuildingProject);
     public const string BuildProjectReferences = nameof(BuildProjectReferences);
     public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
     public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
@@ -39,5 +45,43 @@ public static class MsBuildProperties
     // Others
     public const string GenerateResourceMSBuildArchitecture = nameof(GenerateResourceMSBuildArchitecture);
     public const string NonExistentFile = nameof(NonExistentFile);
-    public const string NoAutoResponse = nameof(NoAutoResponse); // See https://github.com/daveaglick/Buildalyzer/issues/211
+
+    // See https://github.com/daveaglick/Buildalyzer/issues/211
+    public const string NoAutoResponse = nameof(NoAutoResponse);
+
+    /// <summary>
+    /// Gets the MS Build properties equivalent to Visual Studio's DesignTime build.
+    /// </summary>
+    /// <remarks>
+    /// The actual design-time tasks aren't available outside of Visual Studio,
+    /// so we can't do a "real" design-time build and have to fake it with various global properties
+    /// See https://github.com/dotnet/msbuild/blob/fb700f90493a0bf47623511edf28b1d6c114e4fa/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L320
+    /// To diagnose build failures in design-time mode, generate a binary log and find the filing target,
+    /// then see if there's a condition or property that can be used to modify it's behavior or turn it off.
+    /// </remarks>
+    public static readonly IReadOnlyDictionary<string, string> DesignTime = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        [DesignTimeBuild] = "true",
+
+        // Supports Framework projects: https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build    
+        [BuildingProject] = "false",
+        [BuildProjectReferences] = "false",
+        [SkipCompilerExecution] = "true",
+        [DisableRarCache] = "true",
+        [AutoGenerateBindingRedirects] = "false",
+        [CopyBuildOutputToOutputDirectory] = "false",
+        [CopyOutputSymbolsToOutputDirectory] = "false",
+        [CopyDocumentationFileToOutputDirectory] = "false",
+
+        // Prevents the CreateAppHost task from running, which doesn't add the apphost.exe to the files to copy
+        [ComputeNETCoreBuildOutputFiles] = "false",
+        [SkipCopyBuildProduct] = "true",
+        [AddModules] = "false",
+
+        // This is used in a condition to prevent copying in _CopyFilesMarkedCopyLocal
+        [UseCommonOutputDirectory] = "true",
+
+        // Prevent NuGet.Build.Tasks.Pack.targets from running the pack targets (since we didn't build anything)
+        [GeneratePackageOnBuild] = "false",
+    };
 }

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
@@ -15,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="All"/>
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Buildalyzer.Tests/Environment/MsBuildPropertiesFixture.cs
+++ b/tests/Buildalyzer.Tests/Environment/MsBuildPropertiesFixture.cs
@@ -1,0 +1,29 @@
+﻿using Buildalyzer.Environment;
+using FluentAssertions;
+
+namespace Buildalyzer.Tests.Environment;
+
+public class MsBuildPropertiesFixture
+{
+    [Test]
+    public void Provides_DesignTime_properties()
+    {
+        MsBuildProperties.DesignTime.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["DesignTimeBuild"] = "true",
+            ["BuildingProject"] = "false",
+            ["BuildProjectReferences"] = "false",
+            ["SkipCompilerExecution"] = "true",
+            ["DisableRarCache"] = "true",
+            ["AutoGenerateBindingRedirects"] = "false",
+            ["CopyBuildOutputToOutputDirectory"] = "false",
+            ["CopyOutputSymbolsToOutputDirectory"] = "false",
+            ["CopyDocumentationFileToOutputDirectory"] = "false",
+            ["ComputeNETCoreBuildOutputFiles"] = "false",
+            ["SkipCopyBuildProduct"] = "true",
+            ["AddModules"] = "false",
+            ["UseCommonOutputDirectory"] = "true",
+            ["GeneratePackageOnBuild"] = "false",
+        });
+    }
+}

--- a/tests/Buildalyzer.Tests/Properties/GlobalUsings.cs
+++ b/tests/Buildalyzer.Tests/Properties/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.Threading.Tasks;
+global using NUnit.Framework;


### PR DESCRIPTION
The **DesignTime** flag for creating a `BuildEnvironment` contains a set of properties that is set. By this change, those properties are easier to access.