### PR TITLE
feat: adding cache to dotnet --info content

### DIFF
--- a/src/Buildalyzer/Caching/DotnetInfoCache.cs
+++ b/src/Buildalyzer/Caching/DotnetInfoCache.cs
@@ -6,6 +6,7 @@ namespace Buildalyzer.Caching
     {
         private static readonly Dictionary<string, IReadOnlyCollection<string>> Cache = new Dictionary<string, IReadOnlyCollection<string>>();
 
+        [Pure]
         public static IReadOnlyCollection<string> GetCache(string path)
         {
             return Cache.TryGetValue(path, out IReadOnlyCollection<string> values) ? values : null;

--- a/src/Buildalyzer/Caching/DotnetInfoCache.cs
+++ b/src/Buildalyzer/Caching/DotnetInfoCache.cs
@@ -1,0 +1,20 @@
+﻿namespace Buildalyzer.Caching
+{
+    internal static class DotnetInfoCache
+    {
+        private static Dictionary<string, List<string>> cache = new Dictionary<string, List<string>>();
+
+        [Pure]
+        public static List<string> GetCache(string path)
+        {
+            return cache.FirstOrDefault(x => x.Key == path).Value;
+        }
+
+        [Pure]
+        public static Dictionary<string, List<string>> AddCache(string path, List<string> dotnetInfo)
+        {
+            cache.Add(path, dotnetInfo);
+            return cache;
+        }
+    }
+}

--- a/src/Buildalyzer/Caching/DotnetInfoCache.cs
+++ b/src/Buildalyzer/Caching/DotnetInfoCache.cs
@@ -1,20 +1,29 @@
-﻿namespace Buildalyzer.Caching
+﻿using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Caching
 {
     internal static class DotnetInfoCache
     {
-        private static Dictionary<string, List<string>> cache = new Dictionary<string, List<string>>();
+        private static readonly Dictionary<string, IReadOnlyCollection<string>> Cache = new Dictionary<string, IReadOnlyCollection<string>>();
 
-        [Pure]
-        public static List<string> GetCache(string path)
+        public static IReadOnlyCollection<string> GetCache(string path)
         {
-            return cache.FirstOrDefault(x => x.Key == path).Value;
+            return Cache.TryGetValue(path, out IReadOnlyCollection<string> values) ? values : null;
         }
 
-        [Pure]
-        public static Dictionary<string, List<string>> AddCache(string path, List<string> dotnetInfo)
+        public static void AddCache(string path, IReadOnlyCollection<string> dotnetInfo)
         {
-            cache.Add(path, dotnetInfo);
-            return cache;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("The path cannot be null or empty.");
+            }
+
+            if (dotnetInfo == null)
+            {
+                throw new ArgumentNullException(nameof(dotnetInfo), "Dotnet info information cannot be null.");
+            }
+
+            Cache[path] = dotnetInfo;
         }
     }
 }

--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -20,7 +20,7 @@ internal class DotnetPathResolver
     public string ResolvePath(string projectPath, string dotnetExePath)
     {
         dotnetExePath ??= "dotnet";
-        List<string> output = GetInfo(projectPath, dotnetExePath);
+        IReadOnlyCollection<string> output = GetInfo(projectPath, dotnetExePath);
 
         var info = DotNetInfo.Parse(output);
         var basePath = info.BasePath ?? info.Runtimes.Values.FirstOrDefault();
@@ -34,7 +34,7 @@ internal class DotnetPathResolver
         return basePath;
     }
 
-    private List<string> GetInfo(string projectPath, string dotnetExePath)
+    private IReadOnlyCollection<string> GetInfo(string projectPath, string dotnetExePath)
     {
         // Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
         // running 'dotnet --info'. Otherwise, we may get localized results
@@ -47,7 +47,7 @@ internal class DotnetPathResolver
             { MsBuildProperties.MSBuildExtensionsPath, null }
         };
 
-        List<string> dotnetInfoCache = DotnetInfoCache.GetCache(projectPath);
+        IReadOnlyCollection<string> dotnetInfoCache = DotnetInfoCache.GetCache(projectPath);
 
         if (dotnetInfoCache == null)
         {
@@ -60,7 +60,7 @@ internal class DotnetPathResolver
                 _logger?.LogInformation($"dotnet --info wait time is {dotnetInfoWaitTime}ms");
                 processRunner.Start();
                 processRunner.WaitForExit(dotnetInfoWaitTime);
-                List<string> dotnetInfoOutput = processRunner.Output;
+                IReadOnlyCollection<string> dotnetInfoOutput = processRunner.Output;
                 DotnetInfoCache.AddCache(projectPath, dotnetInfoOutput);
                 return dotnetInfoOutput;
             }


### PR DESCRIPTION
### Feature: 
Cache dotnet --info result per project

### Description
In some scenarios, executing dotnet --info may take longer than desired, especially when executed within containers with few resources.

This pr adds a cache where the key is the full path of the project.