### PR TITLE
Fix hang if build does not start

### DIFF
--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -709,6 +709,23 @@ public class SimpleProjectsFixture
             .Should().BeEquivalentTo("message.txt");
     }
 
+    [Test]
+    public void HandlesProcessFailure()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNet6Exe\SdkNet6Exe.csproj", log);
+
+        // When
+        IAnalyzerResults results = analyzer.Build(new EnvironmentOptions
+        {
+            Arguments = { "/unknown" } // This argument will cause msbuild to immediately fail
+        });
+
+        // Then
+        results.OverallSuccess.ShouldBeFalse();
+    }
+
     private static IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log)
     {
         IProjectAnalyzer analyzer = new AnalyzerManager(


### PR DESCRIPTION
Fixes #271

There are other solutions to this, like running `ReadAll` in a `Thread` or `Task` and aborting that. I've also looked at the cancellation token and using that, however it's not being used effectively in `ReadAll` and I don't think there is simple solution as `AnonymousPipeLoggerServer` doesn't support cooperative cancellation as far as I can see.

There may be a memory leak here with the the two events being subscribed to, not sure if we want to try and engineer a better solution.