### PR TITLE
feat: adding alternative for single file publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ If you want to change the configured properties before loading or compiling the 
 
 Be careful though, you may break the ability to load, compile, or interpret the project if you change the MSBuild properties.
 
+
+## Publish SingleFile
+If your application's output is a single file, you will need to provide the path to the following DLLs:
+
+-MsBuildPipeLogger.Logger.dll
+-Buildalyzer.logger.dll
+
+Variable name: LoggerPathDll
+
+See related issue [224](https://github.com/phmonte/Buildalyzer/issues/224)
+msbuild needs the physical address of the logger, for this reason it is not possible to use single file publish without informing this route.
+
+Remembering that if the files are in the root where the project is running, it is not necessary to inform the path.
 ## Binary Log Files
 
 Buildalyzer can also read [MSBuild binary log files](http://msbuildlog.com/):

--- a/src/Buildalyzer/Environment/EnvironmentVariables.cs
+++ b/src/Buildalyzer/Environment/EnvironmentVariables.cs
@@ -14,4 +14,5 @@ public static class EnvironmentVariables
     public const string MSBUILDDISABLENODEREUSE = nameof(MSBUILDDISABLENODEREUSE);
     public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
     public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
+    public const string LoggerPathDll = nameof(LoggerPathDll);
 }

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -279,7 +279,8 @@ public class ProjectAnalyzer : IProjectAnalyzer
         }
 
         // Get the logger arguments (/l)
-        string loggerPath = typeof(BuildalyzerLogger).Assembly.Location;
+        string loggerPath = GetLoggerPath();
+
         bool logEverything = _buildLoggers.Count > 0;
         string loggerArgStart = "/l"; // in case of MSBuild.exe use slash as parameter prefix for logger
         if (isDotNet)
@@ -310,6 +311,23 @@ public class ProjectAnalyzer : IProjectAnalyzer
         arguments += string.Join(" ", argumentsList);
 
         return fileName;
+    }
+
+    private static string GetLoggerPath()
+    {
+        string loggerPath = typeof(BuildalyzerLogger).Assembly.Location;
+        if (!string.IsNullOrEmpty(loggerPath))
+        {
+            return loggerPath;
+        }
+
+        string? loggerDllPathEnv = System.Environment.GetEnvironmentVariable(Environment.EnvironmentVariables.LoggerPathDll);
+        if (string.IsNullOrEmpty(loggerDllPathEnv))
+        {
+            throw new ArgumentException($"The dll of {nameof(BuildalyzerLogger)} is required");
+        }
+
+        return loggerDllPathEnv;
     }
 
     private static string FormatArgument(string argument)


### PR DESCRIPTION
### 🚀 Pull Request Template

## Adding publish single file support.

## Description
If your application's output is a single file, you will need to provide the path to the following DLLs:

`-MsBuildPipeLogger.Logger.dll`
`-Buildalyzer.logger.dll`

Variable name: `LoggerPathDll`

See related issue [224](https://github.com/phmonte/Buildalyzer/issues/224)
msbuild needs the physical address of the logger, for this reason it is not possible to use single file publish without informing this route.

Remembering that if the files are in the root where the project is running, it is not necessary to inform the path.

[x] Readme updated