### PR TITLE
Clean-up code by introducing String compare helpers

### DIFF
--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -8,6 +8,10 @@
     <PackageValidationBaselineVersion>7.0.1</PackageValidationBaselineVersion>
     <OutputType>library</OutputType>
     <PackageReleaseNotes>
+      <![CDATA[
+ToBeReleased
+- Drop Buildalyzer.EmptyDisposable. (BREAKING)
+]]>
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Buildalyzer/Compiler/FSharpCommandLineParser.cs
+++ b/src/Buildalyzer/Compiler/FSharpCommandLineParser.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System;
+
 namespace Buildalyzer;
 
 internal static class FSharpCommandLineParser
@@ -52,8 +54,8 @@ internal static class FSharpCommandLineParser
 
     [Pure]
     public static bool NotCompilerLocation(string s)
-        => !s.EndsWith("fsc.dll", StringComparison.OrdinalIgnoreCase)
-        && !s.EndsWith("fsc.exe", StringComparison.OrdinalIgnoreCase);
+        => !s.IsMatchEnd("fsc.dll")
+        && !s.IsMatchEnd("fsc.exe");
 
     private static readonly char[] Splitters = ['\r', '\n'];
 }

--- a/src/Buildalyzer/Compiler/RoslynCommandLineParser.cs
+++ b/src/Buildalyzer/Compiler/RoslynCommandLineParser.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace Buildalyzer;
@@ -17,7 +18,7 @@ internal static class RoslynCommandLineParser
         {
             for (var i = 0; i < args.Length - 1; i++)
             {
-                if (args[i].EndsWith(exec, StringComparison.OrdinalIgnoreCase))
+                if (args[i].IsMatchEnd(exec))
                 {
                     return args[i..];
                 }

--- a/src/Buildalyzer/Construction/ProjectFile.cs
+++ b/src/Buildalyzer/Construction/ProjectFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Xml.Linq;
 
 namespace Buildalyzer.Construction;
@@ -59,8 +60,8 @@ public class ProjectFile : IProjectFile
 
     /// <inheritdoc />
     public bool RequiresNetFramework =>
-        _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => ImportsThatRequireNetFramework.Exists(i => x.GetAttributeValue(ProjectFileNames.Project)?.EndsWith(i, StringComparison.OrdinalIgnoreCase) ?? false))
-        || _projectElement.GetDescendants(ProjectFileNames.LanguageTargets).Any(x => ImportsThatRequireNetFramework.Exists(i => x.Value.EndsWith(i, StringComparison.OrdinalIgnoreCase)))
+        _projectElement.GetDescendants(ProjectFileNames.Import).Any(x => ImportsThatRequireNetFramework.Exists(i => x.GetAttributeValue(ProjectFileNames.Project)?.IsMatchEnd(i) ?? false))
+        || _projectElement.GetDescendants(ProjectFileNames.LanguageTargets).Any(x => ImportsThatRequireNetFramework.Exists(i => x.Value.IsMatchEnd(i)))
         || ToolsVersion != null;
 
     /// <inheritdoc />

--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -13,7 +13,7 @@ public sealed class BuildEnvironment
         !System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
             .Replace(" ", string.Empty)
             .Trim()
-            .StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase);
+            .IsMatchStart(".NETFramework");
 
     private readonly Dictionary<string, string> _globalProperties;
     private readonly Dictionary<string, string> _environmentVariables;

--- a/src/Buildalyzer/Environment/DotNetInfoParser.cs
+++ b/src/Buildalyzer/Environment/DotNetInfoParser.cs
@@ -1,13 +1,12 @@
 ﻿#nullable enable
 
+using System;
 using System.IO;
 
 namespace Buildalyzer.Environment;
 
 internal static class DotNetInfoParser
 {
-    private const StringComparison IgnoreCase = StringComparison.OrdinalIgnoreCase;
-
     [Pure]
     public static DotNetInfo Parse(IEnumerable<string> lines)
     {
@@ -94,20 +93,20 @@ internal static class DotNetInfoParser
 
     [Pure]
     private static Version? Version(string prefix, string line)
-            => line.StartsWith(prefix, IgnoreCase) && System.Version.TryParse(line[prefix.Length..].Trim(), out var parsed)
+            => line.IsMatchStart(prefix) && System.Version.TryParse(line[prefix.Length..].Trim(), out var parsed)
                 ? parsed
                 : null;
 
     [Pure]
     private static string? Label(string prefix, string line)
-        => line.StartsWith(prefix, IgnoreCase) && line[prefix.Length..].Trim() is { Length: > 0 } label
+        => line.IsMatchStart(prefix) && line[prefix.Length..].Trim() is { Length: > 0 } label
             ? label
             : null;
 
     [Pure]
     private static string? BasePath(string line)
     {
-        if (line.StartsWith("Base Path:", IgnoreCase))
+        if (line.IsMatchStart("Base Path:"))
         {
             var path = line[10..].Trim();
 
@@ -142,8 +141,7 @@ internal static class DotNetInfoParser
     private static string UnifyPath(string path) => path.Replace('\\', '/').TrimEnd('/');
 
     [Pure]
-    private static string? GlobalJson(string line)
-        => line.Equals("Not found", IgnoreCase) ? null : line;
+    private static string? GlobalJson(string line) => line.IsMatch("Not found") ? null : line;
 
     private static readonly HashSet<string> Headers = new(StringComparer.InvariantCultureIgnoreCase)
     {

--- a/src/Buildalyzer/Extensions/System.String.cs
+++ b/src/Buildalyzer/Extensions/System.String.cs
@@ -1,0 +1,24 @@
+﻿namespace System;
+
+internal static class BuildalyzerStringExtensions
+{
+    /// <summary>
+    /// Returns true if the <paramref name="value"/> string has the same value, ignoring casing.
+    /// </summary>
+    [Pure]
+    public static bool IsMatch(this string? self, string? value) => string.Equals(self, value, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true if the string starts with <paramref name="value"/>, ignoring casing.
+    /// </summary>
+    [Pure]
+    public static bool IsMatchStart(this string self, string value)
+        => self.StartsWith(value, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true if the string ends with <paramref name="value"/>, ignoring casing.
+    /// </summary>
+    [Pure]
+    public static bool IsMatchEnd(this string self, string value)
+        => self.EndsWith(value, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Buildalyzer/IO/IOPath.cs
+++ b/src/Buildalyzer/IO/IOPath.cs
@@ -50,7 +50,9 @@ public readonly struct IOPath : IEquatable<IOPath>, IFormattable
     /// <inheritdoc />
     [Pure]
     public bool Equals(IOPath other, bool caseSensitive)
-        => string.Equals(_path, other._path, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        => caseSensitive
+        ? _path == other._path
+        : _path.IsMatch(other._path);
 
     /// <inheritdoc />
     [Pure]

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -152,7 +152,7 @@ internal class EventProcessor : IDisposable
         }
 
         // Process the command line arguments for the Fsc task
-        if (e.SenderName?.Equals("Fsc", StringComparison.OrdinalIgnoreCase) == true
+        if (e.SenderName.IsMatch("Fsc")
             && !string.IsNullOrWhiteSpace(e.Message)
             && _targetStack.Any(x => x.TargetName == "CoreCompile")
             && result.CompilerCommand is null)
@@ -161,14 +161,12 @@ internal class EventProcessor : IDisposable
         }
 
         // Process the command line arguments for the Csc task
-        if (e is TaskCommandLineEventArgs cmd
-            && string.Equals(cmd.TaskName, "Csc", StringComparison.OrdinalIgnoreCase))
+        if (e is TaskCommandLineEventArgs cmd && cmd.TaskName.IsMatch("Csc"))
         {
             result.ProcessCscCommandLine(cmd.CommandLine, _targetStack.Any(x => x.TargetName == "CoreCompile"));
         }
 
-        if (e is TaskCommandLineEventArgs cmdVbc &&
-            string.Equals(cmdVbc.TaskName, "Vbc", StringComparison.OrdinalIgnoreCase))
+        if (e is TaskCommandLineEventArgs cmdVbc && cmdVbc.TaskName.IsMatch("Vbc"))
         {
             result.ProcessVbcCommandLine(cmdVbc.CommandLine);
         }

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -216,7 +216,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
         string initialArguments = string.Empty;
         bool isDotNet = false; // false=MSBuild.exe, true=dotnet.exe
         if (string.IsNullOrWhiteSpace(buildEnvironment.MsBuildExePath)
-            || Path.GetExtension(buildEnvironment.MsBuildExePath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+            || Path.GetExtension(buildEnvironment.MsBuildExePath).IsMatch(".dll"))
         {
             // in case of no MSBuild path or a path to the MSBuild dll, run dotnet
             fileName = buildEnvironment.DotnetExePath;
@@ -256,7 +256,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
             // Setting the TargetFramework MSBuild property tells MSBuild which target framework to use for the outer build
             effectiveGlobalProperties[MsBuildProperties.TargetFramework] = targetFramework;
         }
-        if (Path.GetExtension(ProjectFile.Path).Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
+        if (Path.GetExtension(ProjectFile.Path).IsMatch(".fsproj")
             && effectiveGlobalProperties.ContainsKey(MsBuildProperties.SkipCompilerExecution))
         {
             // We can't skip the compiler for design-time builds in F# (it causes strange errors regarding file copying)

--- a/src/Buildalyzer/XDocumentExtensions.cs
+++ b/src/Buildalyzer/XDocumentExtensions.cs
@@ -5,13 +5,13 @@ namespace Buildalyzer;
 internal static class XDocumentExtensions
 {
     public static IEnumerable<XElement> GetDescendants(this XDocument document, string name) =>
-        document.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+        document.Descendants().Where(x => x.Name.LocalName.IsMatch(name));
 
     public static IEnumerable<XElement> GetDescendants(this XElement element, string name) =>
-        element.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+        element.Descendants().Where(x => x.Name.LocalName.IsMatch(name));
 
-    public static string GetAttributeValue(this XElement element, string name) =>
-        element.Attributes().FirstOrDefault(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value;
+    public static string? GetAttributeValue(this XElement element, string name) =>
+        element.Attributes().FirstOrDefault(x => x.Name.LocalName.IsMatch(name))?.Value;
 
     // Adds a child element with the same namespace as the parent
     public static void AddChildElement(this XElement element, string name, string value) =>


### PR DESCRIPTION
To improve on the readability when comparing strings case insensitive, I've created 3 extension methods:

``` C#
namespace System;

internal static class BuildalyzerStringExtensions
{
    public static bool IsMatch(this string? self, string? value);
    public static bool IsMatchStart(this string self, string value);
    public static bool IsMatchEnd(this string self, string value);
}
```

For obvious reasons this helpers are kept internal, as this should not be a deliverable of Buildalyzer. 