### PR TITLE
Isolate the collection of the ProcessData

### DIFF
--- a/src/Buildalyzer/Environment/DotNetInfoResolver.cs
+++ b/src/Buildalyzer/Environment/DotNetInfoResolver.cs
@@ -42,7 +42,7 @@ internal sealed class DotNetInfoResolver(ILoggerFactory? factory)
         processRunner.Start();
         processRunner.WaitForExit(GetWaitTime());
 
-        var info = DotNetInfo.Parse(processRunner.Output);
+        var info = DotNetInfo.Parse(processRunner.Data.Output);
         Cache[projectPath] = info;
         return info;
     }

--- a/src/Buildalyzer/Environment/ProcessRunner.cs
+++ b/src/Buildalyzer/Environment/ProcessRunner.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Buildalyzer.Environment;
 
-internal class ProcessRunner : IDisposable
+internal sealed class ProcessRunner : IDisposable
 {
     private readonly ILogger Logger;
     private readonly ProcessDataCollector Collector;
@@ -35,7 +35,10 @@ internal class ProcessRunner : IDisposable
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
-            }
+            },
+
+            // Raises Process.Exited immediately instead of when checked via .WaitForExit() or .HasExited
+            EnableRaisingEvents = true,
         };
 
         // Copy over environment variables
@@ -48,23 +51,9 @@ internal class ProcessRunner : IDisposable
             }
         }
 
-        Process.EnableRaisingEvents = true;  // Raises Process.Exited immediately instead of when checked via .WaitForExit() or .HasExited
-        Process.Exited += ProcessExited;
-
-        Process.OutputDataReceived += (_, e) =>
-        {
-            if (!string.IsNullOrEmpty(e.Data))
-            {
-                Logger.LogDebug("{Data}{NewLine}", e.Data, System.Environment.NewLine);
-            }
-        };
-        Process.ErrorDataReceived += (_, e) =>
-        {
-            if (!string.IsNullOrEmpty(e.Data))
-            {
-                Logger.LogError("{Data}{NewLine}", e.Data, System.Environment.NewLine);
-            }
-        };
+        Process.OutputDataReceived += OutputDataReceived;
+        Process.ErrorDataReceived += ErrorDataReceived;
+        Process.Exited += OnExit;
 
         Collector = new(Process);
     }
@@ -83,16 +72,6 @@ internal class ProcessRunner : IDisposable
         return this;
     }
 
-    private void ProcessExited(object? sender, EventArgs e)
-    {
-        Exited?.Invoke();
-        Logger.LogDebug(
-            "Process {Id} exited with code {ExitCode}{NewLine}",
-            Process.Id,
-            Process.ExitCode,
-            System.Environment.NewLine);
-    }
-
     public void WaitForExit() => Process.WaitForExit();
 
     public bool WaitForExit(int timeout)
@@ -108,10 +87,40 @@ internal class ProcessRunner : IDisposable
         return exited;
     }
 
+    private void OutputDataReceived(object sender, DataReceivedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.Data))
+        {
+            Logger.LogDebug("{Data}{NewLine}", e.Data, NewLine);
+        }
+    }
+
+    private void ErrorDataReceived(object sender, DataReceivedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.Data))
+        {
+            Logger.LogError("{Data}{NewLine}", e.Data, NewLine);
+        }
+    }
+
+    private void OnExit(object? sender, EventArgs e)
+    {
+        Exited?.Invoke();
+        Logger.LogDebug(
+            "Process {Id} exited with code {ExitCode}{NewLine}",
+            Process.Id,
+            Process.ExitCode,
+            NewLine);
+    }
+
     public void Dispose()
     {
-        Process.Exited -= ProcessExited;
+        Process.OutputDataReceived -= OutputDataReceived;
+        Process.ErrorDataReceived -= ErrorDataReceived;
+        Process.Exited -= OnExit;
         Process.Close();
         Collector.Dispose();
     }
+
+    private static string NewLine => System.Environment.NewLine;
 }

--- a/src/Buildalyzer/Environment/ProcessRunner.cs
+++ b/src/Buildalyzer/Environment/ProcessRunner.cs
@@ -6,11 +6,11 @@ namespace Buildalyzer.Environment;
 internal class ProcessRunner : IDisposable
 {
     private readonly ILogger Logger;
-
-    public List<string> Output { get; } = new List<string>();
-    public List<string> Error { get; } = new List<string>();
+    private readonly ProcessDataCollector Collector;
 
     public int ExitCode => Process.ExitCode;
+
+    public ProcessData Data => Collector.Data;
 
     private Process Process { get; }
 
@@ -55,7 +55,6 @@ internal class ProcessRunner : IDisposable
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                Output.Add(e.Data);
                 Logger.LogDebug("{Data}{NewLine}", e.Data, System.Environment.NewLine);
             }
         };
@@ -63,10 +62,11 @@ internal class ProcessRunner : IDisposable
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                Error.Add(e.Data);
-                Logger.LogDebug("{Data}{NewLine}", e.Data, System.Environment.NewLine);
+                Logger.LogError("{Data}{NewLine}", e.Data, System.Environment.NewLine);
             }
         };
+
+        Collector = new(Process);
     }
 
     public ProcessRunner Start()
@@ -112,5 +112,6 @@ internal class ProcessRunner : IDisposable
     {
         Process.Exited -= ProcessExited;
         Process.Close();
+        Collector.Dispose();
     }
 }

--- a/src/Buildalyzer/ProcessData.cs
+++ b/src/Buildalyzer/ProcessData.cs
@@ -1,0 +1,14 @@
+﻿namespace Buildalyzer;
+
+/// <summary>The data received during a <see cref="Process" />.</summary>
+[DebuggerDisplay("Output = {Output.Length}, Error = {Error.Length}")]
+public sealed class ProcessData(
+    ImmutableArray<string> output,
+    ImmutableArray<string> error)
+{
+    /// <summary>The collected output of the process.</summary>
+    public ImmutableArray<string> Output { get; } = output;
+
+    /// <summary>The collected errors of the process.</summary>
+    public ImmutableArray<string> Error { get; } = error;
+}

--- a/src/Buildalyzer/ProcessDataCollector.cs
+++ b/src/Buildalyzer/ProcessDataCollector.cs
@@ -1,0 +1,46 @@
+﻿namespace Buildalyzer;
+
+/// <summary>Collects the <see cref="ProcessData"/> durring a <see cref="System.Diagnostics.Process"/>.</summary>
+[DebuggerDisplay("ExitCode = {Process.ExitCode}, Output = {Process.Output.Length}, Error = {Process.Error.Length}")]
+internal sealed class ProcessDataCollector : IDisposable
+{
+    private readonly Process Process;
+    private readonly List<string> Output = [];
+    private readonly List<string> Error = [];
+
+    public ProcessDataCollector(Process process)
+    {
+        Process = process;
+        Process.OutputDataReceived += OutputDataReceived;
+        Process.ErrorDataReceived += ErrorDataReceived;
+    }
+
+    public ProcessData Data => new(
+        Output.ToImmutableArray(),
+        Error.ToImmutableArray());
+
+    private void OutputDataReceived(object? sender, DataReceivedEventArgs e) => Add(e.Data, Output);
+
+    private void ErrorDataReceived(object? sender, DataReceivedEventArgs e) => Add(e.Data, Error);
+
+    private static void Add(string? value, List<string> buffer)
+    {
+        if (value is { Length: > 0 })
+        {
+            buffer.Add(value);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!Disposed)
+        {
+            Process.OutputDataReceived -= OutputDataReceived;
+            Process.ErrorDataReceived -= ErrorDataReceived;
+            Disposed = true;
+        }
+    }
+
+    private bool Disposed;
+}


### PR DESCRIPTION
To reduce the responsibilities of different pieces of code, I think it is a good idea to let a dedicated collector take care of the collection of the  `DataReceivedEventArgs` events fired while running a `Process` in Buildalyzer.