### PR TITLE
Add explicit support for assembly aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}

--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -293,7 +293,7 @@ public static class AnalyzerResultExtensions
     private static IEnumerable<MetadataReference> GetMetadataReferences(IAnalyzerResult analyzerResult) =>
         analyzerResult
             .References?.Where(File.Exists)
-            .Select(x => MetadataReference.CreateFromFile(x))
+            .Select(x => MetadataReference.CreateFromFile(x, new MetadataReferenceProperties(aliases: analyzerResult.ReferenceAliases.GetValueOrDefault(x))))
             ?? [];
 
     private static IEnumerable<AnalyzerReference> GetAnalyzerReferences(IAnalyzerResult analyzerResult, Workspace workspace)

--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -71,6 +71,9 @@ public class AnalyzerResult : IAnalyzerResult
     public string[] References =>
         CompilerCommand?.MetadataReferences.ToArray() ?? [];
 
+    public ImmutableDictionary<string, ImmutableArray<string>> ReferenceAliases => 
+        CompilerCommand?.Aliases ?? ImmutableDictionary<string, ImmutableArray<string>>.Empty;
+
     public string[] AnalyzerReferences =>
           CompilerCommand?.AnalyzerReferences.Select(r => r.ToString()).ToArray() ?? [];
 

--- a/src/Buildalyzer/Compiler/Compiler.cs
+++ b/src/Buildalyzer/Compiler/Compiler.cs
@@ -102,8 +102,8 @@ public static class Compiler
                 AnalyzerReferences = arguments.AnalyzerReferences.Select(AsIOPath).ToImmutableArray(),
                 AnalyzerConfigPaths = arguments.AnalyzerConfigPaths.Select(IOPath.Parse).ToImmutableArray(),
                 MetadataReferences = arguments.MetadataReferences.Select(m => m.Reference).ToImmutableArray(),
+                Aliases = arguments.MetadataReferences.ToImmutableDictionary(m=>m.Reference, m => m.Properties.Aliases),
                 PreprocessorSymbolNames = arguments.ParseOptions.PreprocessorSymbolNames.ToImmutableArray(),
-
                 SourceFiles = arguments.SourceFiles.Select(AsIOPath).ToImmutableArray(),
                 AdditionalFiles = arguments.AdditionalFiles.Select(AsIOPath).ToImmutableArray(),
                 EmbeddedFiles = arguments.EmbeddedFiles.Select(AsIOPath).ToImmutableArray(),

--- a/src/Buildalyzer/Compiler/Compiler.cs
+++ b/src/Buildalyzer/Compiler/Compiler.cs
@@ -102,7 +102,7 @@ public static class Compiler
                 AnalyzerReferences = arguments.AnalyzerReferences.Select(AsIOPath).ToImmutableArray(),
                 AnalyzerConfigPaths = arguments.AnalyzerConfigPaths.Select(IOPath.Parse).ToImmutableArray(),
                 MetadataReferences = arguments.MetadataReferences.Select(m => m.Reference).ToImmutableArray(),
-                Aliases = arguments.MetadataReferences.ToImmutableDictionary(m=>m.Reference, m => m.Properties.Aliases),
+                Aliases = arguments.MetadataReferences.Where(m => !m.Properties.Aliases.IsEmpty).ToImmutableDictionary(m => m.Reference, m => m.Properties.Aliases),
                 PreprocessorSymbolNames = arguments.ParseOptions.PreprocessorSymbolNames.ToImmutableArray(),
                 SourceFiles = arguments.SourceFiles.Select(AsIOPath).ToImmutableArray(),
                 AdditionalFiles = arguments.AdditionalFiles.Select(AsIOPath).ToImmutableArray(),

--- a/src/Buildalyzer/Compiler/CompilerCommand.cs
+++ b/src/Buildalyzer/Compiler/CompilerCommand.cs
@@ -45,6 +45,11 @@ public abstract record CompilerCommand
     /// <inheritdoc  cref="CommandLineArguments.MetadataReferences" />
     public ImmutableArray<string> MetadataReferences { get; init; }
 
+    /// <summary>
+    /// The aliases used in the command line arguments.
+    /// </summary>
+    public ImmutableDictionary<string, ImmutableArray<string>> Aliases { get; init; }
+
     /// <inheritdoc />
     [Pure]
     public override string ToString() => Text ?? string.Empty;

--- a/src/Buildalyzer/IAnalyzerResult.cs
+++ b/src/Buildalyzer/IAnalyzerResult.cs
@@ -38,6 +38,8 @@ public interface IAnalyzerResult
 
     string[] References { get; }
 
+    ImmutableDictionary<string, ImmutableArray<string>> ReferenceAliases {get; }
+
     string[] AnalyzerReferences { get; }
 
     string[] SourceFiles { get; }

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -174,7 +174,6 @@ internal class EventProcessor : IDisposable
         }
 
         bool IsRelevant() => string.IsNullOrEmpty(result.Command) || AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath;
-        
     }
 
     private void BuildFinished(object sender, BuildFinishedEventArgs e)

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -41,6 +41,7 @@ public class SimpleProjectsFixture
         @"SdkNet6ImplicitUsings\SdkNet6ImplicitUsings.csproj",
         @"SdkNet7Project\SdkNet7Project.csproj",
         @"SdkNet8CS12FeaturesProject\SdkNet8CS12FeaturesProject.csproj",
+        @"SdkNet8Alias\SdkNet8Alias.csproj",
         @"SdkNetCore2ProjectImport\SdkNetCore2ProjectImport.csproj",
         @"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj",
         @"SdkNetCore2ProjectWithImportedProps\SdkNetCore2ProjectWithImportedProps.csproj",

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -198,6 +198,25 @@ public class ProjectAnalyzerExtensionsFixture
         diagnostics.ShouldBeEmpty();
     }
 
+
+    [Test(Description = "Test Reference Alias support")]
+
+    public async Task SupportAssemblyAliases()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNet8Alias\SdkNet8Alias.csproj", log);
+        AdhocWorkspace workspace = analyzer.GetWorkspace();
+        Project project = workspace.CurrentSolution.Projects.Single();
+
+        // When
+        Compilation compilation = await project.GetCompilationAsync();
+
+        Diagnostic[] diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+
+        diagnostics.ShouldBeEmpty();
+    }
+
 #if Is_Windows
     [Test]
     public void HandlesWpfCustomControlLibrary()

--- a/tests/projects/SdkNet8Alias/Class1.cs
+++ b/tests/projects/SdkNet8Alias/Class1.cs
@@ -1,17 +1,15 @@
 ﻿extern alias Alias;
-extern alias OtherAlias;
 
 using Alias::Xunit;
-using OtherAlias::SdkNet8CS12FeaturesProject;
 
 namespace SdkNet8Alias
 {
-    public class UnitTest1
+    public class Class1
     {
         [Fact]
         public void Test1()
         {
-            var t = new Class1();
+
         }
     }
 }

--- a/tests/projects/SdkNet8Alias/SdkNet8Alias.csproj
+++ b/tests/projects/SdkNet8Alias/SdkNet8Alias.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.2">
+      <Aliases>Alias</Aliases>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SdkNet8CS12FeaturesProject\SdkNet8CS12FeaturesProject.csproj">
+      <Aliases>OtherAlias</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/projects/SdkNet8Alias/SdkNet8Alias.csproj
+++ b/tests/projects/SdkNet8Alias/SdkNet8Alias.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,12 +24,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\SdkNet8CS12FeaturesProject\SdkNet8CS12FeaturesProject.csproj">
-      <Aliases>OtherAlias</Aliases>
-    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/projects/SdkNet8Alias/UnitTest1.cs
+++ b/tests/projects/SdkNet8Alias/UnitTest1.cs
@@ -1,0 +1,17 @@
+﻿extern alias Alias;
+extern alias OtherAlias;
+
+using Alias::Xunit;
+using OtherAlias::SdkNet8CS12FeaturesProject;
+
+namespace SdkNet8Alias
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            var t = new Class1();
+        }
+    }
+}

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -60,6 +60,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNet7Project", "SdkNet7Pr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNet8CS12FeaturesProject", "SdkNet8CS12FeaturesProject\SdkNet8CS12FeaturesProject.csproj", "{6DDD74AB-8821-4267-8DC2-8864A3BB5871}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SdkNet8Alias", "SdkNet8Alias\SdkNet8Alias.csproj", "{1646FB0E-BAF2-45D0-9CD5-19EF7310FFC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureFunctionProject", "AzureFunctionProject\AzureFunctionProject.csproj", "{A6411BE0-55A6-4D44-9F1C-FA6B674B832A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -178,6 +182,14 @@ Global
 		{6DDD74AB-8821-4267-8DC2-8864A3BB5871}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DDD74AB-8821-4267-8DC2-8864A3BB5871}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DDD74AB-8821-4267-8DC2-8864A3BB5871}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1646FB0E-BAF2-45D0-9CD5-19EF7310FFC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1646FB0E-BAF2-45D0-9CD5-19EF7310FFC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1646FB0E-BAF2-45D0-9CD5-19EF7310FFC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1646FB0E-BAF2-45D0-9CD5-19EF7310FFC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6411BE0-55A6-4D44-9F1C-FA6B674B832A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6411BE0-55A6-4D44-9F1C-FA6B674B832A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6411BE0-55A6-4D44-9F1C-FA6B674B832A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6411BE0-55A6-4D44-9F1C-FA6B674B832A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### 🚀 Support Assembly Aliases

## Description
This PR adds explicit support for [assembly aliases](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/inputs#references), that is the ability to add a prefix (_an alias_) to the namespace(s) of one or more assemblies in order to deal with name conflict.

This PR adds a `ReferenceAliases` property to `IAnalyzerResult` interface. This property exposes a dictionary providing the list of aliases for every aliased references. If a referenced assembly is not aliased, it will not be listed in this dictionary.

This property is also used for Roslyn Workspace building.

## Tests
A dedicated test project (`SdkNet8Alias`) has been added and is used in integration tests and workspace tests.