### PR TITLE
Use AwesomeAssertions instead of FluentAssertions

### DIFF
--- a/package.props
+++ b/package.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Build extensions">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.1.0" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -14,9 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="6.12.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
-    
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
@@ -28,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="AwesomeAssertions.Analyzers" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="6.12.2" />
-    <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="6.12.2" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
@@ -21,7 +21,7 @@
 
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="AwesomeAssertions.Analyzers" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
[FluentAssertions recently changed its license](https://www.infoq.com/news/2025/01/fluent-assertions-v8-license/) to a commercial one. Although we are not directly affected, as this project is open source (and open source projects can keep using it), I think it is better to switch to a [fork](https://github.com/AwesomeAssertions/AwesomeAssertions) that is licensed under [Apache 2.0](https://github.com/AwesomeAssertions/AwesomeAssertions?tab=Apache-2.0-1-ov-file#readme).