### PR TITLE
migrate from MSBuild SolutionFile to VS SolutionModel

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
 
 namespace Buildalyzer.Workspaces;
 
@@ -43,8 +43,8 @@ public static class AnalyzerManagerExtensions
             workspace.AddSolution(solutionInfo);
 
             // Sort the projects so the order that they're added to the workspace in the same order as the solution file
-            List<ProjectInSolution> projectsInOrder = [.. manager.SolutionFile.ProjectsInOrder];
-            results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
+            List<SolutionProjectModel> projectsInOrder = [.. manager.SolutionFile.SolutionProjects];
+            results = results.OrderBy(p => projectsInOrder.FindIndex(g => g.FilePath == p.ProjectFilePath)).ToList();
         }
 
         // Add each result to the new workspace (sorted in solution order above, if we have a solution)

--- a/src/Buildalyzer/AnalyzerManagerOptions.cs
+++ b/src/Buildalyzer/AnalyzerManagerOptions.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Buildalyzer.Logging;
-using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
 
 namespace Buildalyzer;
 
@@ -13,7 +13,7 @@ public class AnalyzerManagerOptions
     /// A filter that indicates whether a give project should be loaded.
     /// Return <c>true</c> to load the project, <c>false</c> to filter it out.
     /// </summary>
-    public Func<ProjectInSolution, bool>? ProjectFilter { get; set; }
+    public Func<SolutionProjectModel, bool>? ProjectFilter { get; set; }
 
     public TextWriter? LogWriter
     {

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -25,6 +25,7 @@ ToBeReleased
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.158" Aliases="StructuredLogger" />
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
     <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildalyzer/IAnalyzerManager.cs
+++ b/src/Buildalyzer/IAnalyzerManager.cs
@@ -1,5 +1,5 @@
-using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
 
 namespace Buildalyzer;
 
@@ -9,7 +9,7 @@ public interface IAnalyzerManager
 
     IReadOnlyDictionary<string, IProjectAnalyzer> Projects { get; }
 
-    SolutionFile SolutionFile { get; }
+    SolutionModel SolutionFile { get; }
 
     string SolutionFilePath { get; }
 

--- a/src/Buildalyzer/IProjectAnalyzer.cs
+++ b/src/Buildalyzer/IProjectAnalyzer.cs
@@ -3,6 +3,7 @@ using Buildalyzer.Environment;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
 
 namespace Buildalyzer;
 
@@ -46,7 +47,7 @@ public interface IProjectAnalyzer
     /// </summary>
     Guid ProjectGuid { get; }
 
-    ProjectInSolution ProjectInSolution { get; }
+    SolutionProjectModel ProjectInSolution { get; }
 
     string SolutionDirectory { get; }
 

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -5,9 +5,9 @@ using Buildalyzer.Construction;
 using Buildalyzer.Environment;
 using Buildalyzer.Logger;
 using Buildalyzer.Logging;
-using Microsoft.Build.Construction;
 using Microsoft.Build.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
 using MsBuildPipeLogger;
 using ILogger = Microsoft.Build.Framework.ILogger;
 
@@ -30,7 +30,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
 
     public string SolutionDirectory { get; }
 
-    public ProjectInSolution ProjectInSolution { get; }
+    public SolutionProjectModel ProjectInSolution { get; }
 
     /// <inheritdoc/>
     public Guid ProjectGuid { get; }
@@ -49,7 +49,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
     public bool IgnoreFaultyImports { get; set; } = true;
 
     // The project file path should already be normalized
-    internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath, ProjectInSolution projectInSolution)
+    internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath, SolutionProjectModel projectInSolution)
     {
         Manager = manager;
         Logger = Manager.LoggerFactory?.CreateLogger<ProjectAnalyzer>();
@@ -62,7 +62,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
         // Get (or create) a project GUID
         ProjectGuid = projectInSolution == null
             ? Buildalyzer.ProjectGuid.Create(ProjectFile.Name)
-            : Guid.Parse(projectInSolution.ProjectGuid);
+            : projectInSolution.Id;
 
         // Set the solution directory global property
         SetGlobalProperty(MsBuildProperties.SolutionDir, SolutionDirectory);

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -484,7 +484,7 @@ public class SimpleProjectsFixture
             new AnalyzerManagerOptions
             {
                 LogWriter = log,
-                ProjectFilter = x => x.AbsolutePath.Contains("Core")
+                ProjectFilter = x => x.FilePath.Contains("Core")
             });
 
         // Then


### PR DESCRIPTION
### 🚀 Pull Request Template

Fixes #303 

## Description
This PR uses the new VS.SolutionPersistence library to parse both classic solution files and new SLNX files. As a result it removes the usage of the MSBuild SolutionFile models. This is an API breaking change, but is how the whole ecosystem is moving.

*If it is a draft, describe the next steps
*Remember to create tests whenever possible